### PR TITLE
fix: resolve agent binary on macOS when launched from Spotlight/Dock

### DIFF
--- a/crates/scryer-acp/src/lib.rs
+++ b/crates/scryer-acp/src/lib.rs
@@ -6,33 +6,6 @@ pub mod runtime;
 pub use events::AgentEvent;
 pub use runtime::AcpRuntime;
 
-/// macOS GUI apps launched via Spotlight, Dock, or Finder inherit a minimal
-/// PATH (`/usr/bin:/bin:/usr/sbin:/sbin`) that excludes user-local install
-/// directories like `~/.local/bin`, `/opt/homebrew/bin`, or `/usr/local/bin`.
-/// Append common locations so that `which::which()` can find agent binaries.
-#[cfg(target_os = "macos")]
-fn ensure_common_paths() {
-    use std::sync::Once;
-    static ONCE: Once = Once::new();
-    ONCE.call_once(|| {
-        let current = std::env::var("PATH").unwrap_or_default();
-        let home = std::env::var("HOME").unwrap_or_else(|_| "/Users/nobody".into());
-        let extra = [
-            format!("{home}/.local/bin"),
-            "/usr/local/bin".into(),
-            "/opt/homebrew/bin".into(),
-            format!("{home}/.cargo/bin"),
-        ];
-        let mut parts: Vec<&str> = current.split(':').collect();
-        for dir in &extra {
-            if !parts.contains(&dir.as_str()) {
-                parts.push(dir);
-            }
-        }
-        std::env::set_var("PATH", parts.join(":"));
-    });
-}
-
 /// Read the active MCP client identity written by scryer-mcp on connection.
 /// Returns (name, version) if available.
 pub fn active_client() -> Option<ActiveClient> {
@@ -63,9 +36,6 @@ pub enum AgentLaunch {
 /// Resolve an MCP client name to a launch config.
 /// Known CLI agents get Cli mode; others fall back to ACP conventions.
 pub fn resolve_agent_binary(client_name: &str) -> Option<AgentLaunch> {
-    #[cfg(target_os = "macos")]
-    ensure_common_paths();
-
     // Known CLI agents that support print mode
     match client_name {
         "claude-code" => {

--- a/crates/scryer-acp/src/lib.rs
+++ b/crates/scryer-acp/src/lib.rs
@@ -6,6 +6,33 @@ pub mod runtime;
 pub use events::AgentEvent;
 pub use runtime::AcpRuntime;
 
+/// macOS GUI apps launched via Spotlight, Dock, or Finder inherit a minimal
+/// PATH (`/usr/bin:/bin:/usr/sbin:/sbin`) that excludes user-local install
+/// directories like `~/.local/bin`, `/opt/homebrew/bin`, or `/usr/local/bin`.
+/// Append common locations so that `which::which()` can find agent binaries.
+#[cfg(target_os = "macos")]
+fn ensure_common_paths() {
+    use std::sync::Once;
+    static ONCE: Once = Once::new();
+    ONCE.call_once(|| {
+        let current = std::env::var("PATH").unwrap_or_default();
+        let home = std::env::var("HOME").unwrap_or_else(|_| "/Users/nobody".into());
+        let extra = [
+            format!("{home}/.local/bin"),
+            "/usr/local/bin".into(),
+            "/opt/homebrew/bin".into(),
+            format!("{home}/.cargo/bin"),
+        ];
+        let mut parts: Vec<&str> = current.split(':').collect();
+        for dir in &extra {
+            if !parts.contains(&dir.as_str()) {
+                parts.push(dir);
+            }
+        }
+        std::env::set_var("PATH", parts.join(":"));
+    });
+}
+
 /// Read the active MCP client identity written by scryer-mcp on connection.
 /// Returns (name, version) if available.
 pub fn active_client() -> Option<ActiveClient> {
@@ -36,6 +63,9 @@ pub enum AgentLaunch {
 /// Resolve an MCP client name to a launch config.
 /// Known CLI agents get Cli mode; others fall back to ACP conventions.
 pub fn resolve_agent_binary(client_name: &str) -> Option<AgentLaunch> {
+    #[cfg(target_os = "macos")]
+    ensure_common_paths();
+
     // Known CLI agents that support print mode
     match client_name {
         "claude-code" => {

--- a/src-tauri/src/lib.rs
+++ b/src-tauri/src/lib.rs
@@ -5,6 +5,41 @@ use std::sync::{Arc, Mutex};
 use notify::{recommended_watcher, EventKind, RecursiveMode, Watcher};
 use tauri::{Emitter, Manager, path::BaseDirectory};
 
+/// macOS GUI apps launched via Spotlight, Dock, or Finder inherit a minimal
+/// PATH (`/usr/bin:/bin:/usr/sbin:/sbin`) that excludes user-installed tools.
+/// Recover the user's real PATH by asking their login shell directly.
+#[cfg(target_os = "macos")]
+fn ensure_full_path() {
+    use std::sync::Once;
+    static ONCE: Once = Once::new();
+    ONCE.call_once(|| {
+        let shell = std::env::var("SHELL").unwrap_or_else(|_| "/bin/zsh".into());
+
+        // Fish outputs PATH as space-separated; ask it for colon-separated
+        let echo_cmd = if shell.ends_with("/fish") {
+            "string join : $PATH"
+        } else {
+            "echo $PATH"
+        };
+
+        let Ok(output) = std::process::Command::new(&shell)
+            .args(["-l", "-c", echo_cmd])
+            .stdin(std::process::Stdio::null())
+            .stderr(std::process::Stdio::null())
+            .output()
+        else {
+            return;
+        };
+
+        if output.status.success() {
+            let shell_path = String::from_utf8_lossy(&output.stdout).trim().to_string();
+            if !shell_path.is_empty() {
+                std::env::set_var("PATH", &shell_path);
+            }
+        }
+    });
+}
+
 /// Managed state wrapping the AI settings.
 struct SettingsState(Arc<Mutex<scryer_core::AiSettings>>);
 
@@ -666,6 +701,9 @@ fn sync_diff(
 
 #[cfg_attr(mobile, tauri::mobile_entry_point)]
 pub fn run() {
+    #[cfg(target_os = "macos")]
+    ensure_full_path();
+
     let settings = scryer_core::read_settings();
     let settings_state = Arc::new(Mutex::new(settings));
 


### PR DESCRIPTION
 ## Summary

  Fix agent binary discovery failing when scryer is launched from macOS Spotlight, Dock, or Finder.

  ## Problem

  macOS GUI apps inherit a minimal PATH (`/usr/bin:/bin:/usr/sbin:/sbin`) that excludes directories where agent binaries are typically installed:

  - `~/.local/bin` (Claude Code via `npm install -g @anthropic-ai/claude-code`)
  - `/usr/local/bin` (Homebrew on Intel Macs, manual installs)
  - `/opt/homebrew/bin` (Homebrew on Apple Silicon)
  - `~/.cargo/bin` (Rust-based tools)

  This causes `which::which("claude")` to fail in `resolve_agent_binary()`, which either:
  - Hides the sync bar entirely (`activeAgent.available = false`)
  - Falls through to an ACP adapter that may not exist or work

  When launched from a terminal, the full shell PATH is inherited and everything works fine — making this a frustrating Heisenbug.

  ## Fix

  Add `ensure_common_paths()` in `crates/scryer-acp/src/lib.rs` that appends common install directories to PATH before calling `which::which()`. Runs once per
  process via `std::sync::Once`, only compiled on macOS (`#[cfg(target_os = "macos")]`).

  **Verified:** Spotlight-launched scryer gets `PATH=/usr/bin:/bin:/usr/sbin:/sbin` → after fix, `~/.local/bin` etc. are appended → `claude` is found → CLI sync
  works.

  ## Test plan

  - [x] `cargo build -p scryer-acp` compiles without warnings
  - [x] `pnpm tauri build` produces working app bundle
  - [x] Launch from Spotlight → sync bar visible with "claude-code" agent
  - [x] "Sync from codebase" works end-to-end