### PR TITLE
Copilot CLI support: MCP, session hooks, and ACP launch

### DIFF
--- a/README.md
+++ b/README.md
@@ -97,7 +97,9 @@ Scryer works with **Claude Code**, **Codex** and **GitHub Copilot CLI**.
 
 When an agent connects via MCP, Scryer captures its identity from the protocol handshake. When a build or sync is triggered, Scryer resolves that identity to a binary and launches it with the right flags.
 
-**Copilot notes.** Copilot reads the same project `.mcp.json` Claude Code does, so one file serves both. Two things differ from the others: it reaches Scryer *only* through that file (its ACP mode doesn't accept a stdio MCP server over the protocol), and it loads a project's MCP servers and hooks only in a folder you've **trusted** — it asks the first time you open one. Until you do, it stays quiet about both. Copilot also fronts several model providers on one subscription, so its model list spans Claude, GPT and Gemini; pick one under Subagent settings.
+**Copilot notes.** Copilot reads the same project `.mcp.json` Claude Code does, so one file serves both. Two things differ from the others: it reaches Scryer *only* through that file (its ACP mode doesn't accept a stdio MCP server over the protocol), and it loads a project's MCP servers and hooks only in a folder you've **trusted** — it asks the first time you open one. Until you do, it stays quiet about both.
+
+Copilot fronts several model providers on one subscription, so its model list spans Claude, GPT and Gemini; pick one under Subagent settings. If you type a model name by hand there, check the spelling — run `copilot help config` for the current list. Copilot ignores an unrecognised model in ACP mode rather than reporting it, so a typo runs on its default model instead of failing.
 
 ## MCP server
 

--- a/README.md
+++ b/README.md
@@ -39,7 +39,7 @@ Coding agents write faster than you can review. You end up shipping code you don
 
 The model describes what each part is responsible for — not its class-by-class structure — in short, language-independent claims on an opinionated [C4](https://c4model.com/)-style hierarchy. It isn't UML, and it isn't your code redrawn as boxes. You plan a change in the model first; the agent reads it over MCP and builds code to match, so the model stays ahead of the code rather than lagging behind it. Underneath, a deterministic observability layer (no LLM) reports what's built versus planned, source and test coverage, and drift in both directions.
 
-Works with <b>Claude Code</b> and <b>Codex</b> out of the box. Any agent that supports [MCP](https://modelcontextprotocol.io/) can read and write the model.
+Works with <b>Claude Code</b>, <b>Codex</b> and <b>GitHub Copilot CLI</b> out of the box. Any agent that supports [MCP](https://modelcontextprotocol.io/) can read and write the model.
 
 ## Features
 
@@ -56,7 +56,7 @@ Works with <b>Claude Code</b> and <b>Codex</b> out of the box. Any agent that su
 - **Build from a codebase** — Point an agent at a project and it scans the code to populate the model.
 - **Diagram view** — A diagram renders the model one level at a time for spatial navigation. Drag cards where you want them — placements persist, and auto-layout manages the rest.
 - **MCP server** — Agents connect to read, modify, and build from the model in real time.
-- **AI tool setup** — Detects Claude Code and Codex and writes MCP config and auto-approve permissions. Optionally installs a Claude Code statusLine that reports the model's pending work and drift even while Scryer is closed.
+- **AI tool setup** — Detects Claude Code, Codex and Copilot CLI and writes MCP config and auto-approve permissions. Session hooks put the model in front of the agent as it works, per project and per tool. Optionally installs a Claude Code statusLine that reports the model's pending work and drift even while Scryer is closed.
 
 ## Getting started
 
@@ -88,13 +88,16 @@ This is how the model stays ahead of the code: intent is captured as a plan befo
 
 ## Agent support
 
-Scryer is built to work with **Claude Code** and **Codex** first.
+Scryer works with **Claude Code**, **Codex** and **GitHub Copilot CLI**.
 
 - **MCP** (Model Context Protocol) — how agents read and write architecture models. Required for any agent integration.
 - **CLI spawning** — how Scryer launches agents for automated model builds and drift sync. Claude Code is spawned via `claude -p` (uses your subscription), Codex via `codex exec` (uses your API key). Both get the Scryer MCP server attached automatically.
-- **ACP** (Agent Client Protocol) — for agents that implement the full ACP handshake (e.g. via [claude-agent-acp](https://github.com/zed-industries/claude-agent-acp)). Scryer falls back to ACP if a `{name}-acp` binary is found on PATH.
+- **ACP** (Agent Client Protocol) — Copilot CLI serves ACP from its own binary (`copilot --acp`), so that's how Scryer launches it; any other agent with a `{name}-acp` adapter on PATH is launched the same way.
+- **Session hooks** — an optional, per-project opt-in for all three: the model's status on session start, the claims governing a file as the agent works in it, and a one-time close check for claims it touched. Inert whenever the Scryer app isn't open on the project.
 
-When an agent connects via MCP, Scryer captures its identity from the protocol handshake. When a build or sync is triggered, Scryer resolves that identity to a binary and launches it with the right flags. Claude Code and Codex are mapped automatically. For other agents, Scryer tries ACP conventions.
+When an agent connects via MCP, Scryer captures its identity from the protocol handshake. When a build or sync is triggered, Scryer resolves that identity to a binary and launches it with the right flags.
+
+**Copilot notes.** Copilot reads the same project `.mcp.json` Claude Code does, so one file serves both. Two things differ from the others: it reaches Scryer *only* through that file (its ACP mode doesn't accept a stdio MCP server over the protocol), and it loads a project's MCP servers and hooks only in a folder you've **trusted** — it asks the first time you open one. Until you do, it stays quiet about both. Copilot also fronts several model providers on one subscription, so its model list spans Claude, GPT and Gemini; pick one under Subagent settings.
 
 ## MCP server
 
@@ -106,8 +109,11 @@ Link a project directory in the app and click "Enable" on the prompt, or run `sc
 
 - **Claude Code** — `.mcp.json` + tool auto-approve in `.claude/settings.local.json`
 - **Codex** — `.codex/config.toml`
+- **Copilot CLI** — `.mcp.json`, the same file Claude Code reads (Copilot also accepts a committed `.github/mcp.json`, if you'd rather keep it there)
 
 Existing config files are preserved — only the `scryer` entry is added or updated.
+
+Session hooks are a separate opt-in, per tool, from Subagent settings: `.claude/settings.local.json`, `.codex/hooks.json`, or `.github/hooks/scryer.json` for Copilot.
 
 For Claude Code you can also install a **statusLine** (from the app, or `scryer-mcp init --statusline`): a one-line model status — pending work, drift scopes, and changes in flight — in every Claude Code session. It reads the model straight off disk, so it keeps reporting while Scryer is closed.
 
@@ -182,7 +188,7 @@ Architecture models go stale as code changes. Scryer detects drift deterministic
 When drift is detected:
 
 1. A review surface and drift indicators flag the potentially drifted scopes — click through to the affected node pages.
-2. Trigger a drift check to spawn your agent (Claude Code via `claude -p`, Codex via `codex exec`) with Scryer's MCP server attached. Drifted scopes are checked in parallel, and each agent gets the changed code embedded inline as evidence, so it judges divergence without re-reading the tree and updates the model only where code has actually diverged.
+2. Trigger a drift check to spawn your agent (Claude Code via `claude -p`, Codex via `codex exec`, Copilot via `copilot --acp`) with Scryer's MCP server attached. Drifted scopes are checked in parallel, and each agent gets the changed code embedded inline as evidence, so it judges divergence without re-reading the tree and updates the model only where code has actually diverged.
 3. Undescribed behavior is proposed into the plan as a **vagrant** claim for you to adopt or reject; a **stale** claim is flagged on the committed model where the code regressed from what was claimed.
 4. Model changes appear in the editor in real time. When every scope has been examined, the drift anchor advances so the same changes stop surfacing.
 

--- a/crates/scryer-acp/examples/acp_smoke.rs
+++ b/crates/scryer-acp/examples/acp_smoke.rs
@@ -1,0 +1,100 @@
+//! Drive one real ACP session end to end and print what comes back.
+//!
+//! The ACP path is the fallback for agents scryer doesn't spawn in print mode —
+//! Copilot CLI, and any `{name}-acp` adapter — so the things worth checking are
+//! that the binary starts in ACP mode at all, that `session/new` carries the
+//! scryer MCP server into the session, and that the agent can actually call it.
+//! This asks the agent to do exactly that and reports the tool calls it makes.
+//!
+//! Usage:
+//!   SCRYER_MCP=/path/to/scryer-mcp \
+//!   cargo run -p scryer-acp --example acp_smoke -- <project> [agent-name]
+//!
+//! `agent-name` is an MCP client name (e.g. `copilot`); omitted, the configured
+//! agent preference decides. The project needs a `.scryer/` model for the MCP
+//! call to have anything to answer with.
+
+use scryer_acp::{AcpKind, AgentEvent, AgentLaunch};
+
+#[tokio::main(flavor = "current_thread")]
+async fn main() {
+    let args: Vec<String> = std::env::args().skip(1).collect();
+    let Some(project) = args.first() else {
+        eprintln!("usage: acp_smoke <project> [agent-name]");
+        std::process::exit(2);
+    };
+    let mcp_binary = std::env::var("SCRYER_MCP").unwrap_or_else(|_| "scryer-mcp".into());
+    let settings = scryer_core::read_subagent_settings();
+
+    let launch = match args.get(1) {
+        Some(name) => scryer_acp::resolve_agent_binary(name),
+        None => scryer_acp::detect_available_agent_pref(&settings.agent),
+    }
+    .expect("no agent resolved — is it on PATH?");
+
+    let (binary, kind) = match launch {
+        AgentLaunch::Acp { binary, kind } => (binary, kind),
+        AgentLaunch::Cli { binary, .. } => {
+            eprintln!("{binary} resolves to CLI print mode, not ACP — nothing to smoke here.");
+            std::process::exit(2);
+        }
+    };
+    let (model_name, effort) = match kind {
+        AcpKind::Copilot => (settings.copilot.model.clone(), settings.copilot.effort.clone()),
+        AcpKind::Adapter => (String::new(), String::new()),
+    };
+    eprintln!("[smoke] {binary} (model {model_name:?}, effort {effort:?}) on {project}");
+
+    let runtime = scryer_acp::AcpRuntime::new();
+    let (tx, mut rx) = tokio::sync::mpsc::unbounded_channel();
+    let session = runtime
+        .start_session(
+            binary,
+            scryer_acp::runtime::LaunchMode::Acp { kind },
+            project.clone(),
+            model_name,
+            effort,
+            mcp_binary,
+            "Call the scryer MCP tool `get_health` and reply with ONLY the first line of \
+             its output. Do not read any files."
+                .to_string(),
+            vec!["mcp__scryer__*".into()],
+            tx,
+        )
+        .await
+        .expect("session start");
+    eprintln!("[smoke] session {session}");
+
+    let mut saw_tool_call = false;
+    while let Some(event) = rx.recv().await {
+        match event {
+            AgentEvent::Message { text } => println!("{text}"),
+            AgentEvent::Thought { text } => eprintln!("[smoke] thought: {text}"),
+            AgentEvent::ToolCall { name, status, .. } => {
+                if name.contains("get_health") || name.contains("scryer") {
+                    saw_tool_call = true;
+                }
+                eprintln!("[smoke] tool: {name} ({status})");
+            }
+            AgentEvent::Plan { content } => eprintln!("[smoke] plan: {content}"),
+            AgentEvent::Activity => {}
+            AgentEvent::Usage { usage } => eprintln!("[smoke] usage: {usage:?}"),
+            AgentEvent::Completed { stop_reason } => {
+                eprintln!("[smoke] completed: {stop_reason}");
+                break;
+            }
+            AgentEvent::Failed { error } => {
+                eprintln!("[smoke] FAILED: {error}");
+                std::process::exit(1);
+            }
+            AgentEvent::Cancelled => {
+                eprintln!("[smoke] cancelled");
+                break;
+            }
+        }
+    }
+    eprintln!(
+        "[smoke] scryer MCP reached from inside the session: {}",
+        if saw_tool_call { "yes" } else { "NO" }
+    );
+}

--- a/crates/scryer-acp/src/lib.rs
+++ b/crates/scryer-acp/src/lib.rs
@@ -15,6 +15,22 @@ pub enum AgentKind {
     Other,
 }
 
+/// Which ACP dialect a subprocess speaks — what to put on its command line
+/// before the protocol takes over. The handshake itself is identical either
+/// way; this only decides argv.
+#[derive(Debug, Clone, serde::Serialize, serde::Deserialize, PartialEq, Eq)]
+#[serde(rename_all = "camelCase")]
+pub enum AcpKind {
+    /// Copilot CLI, which serves ACP from its own binary rather than an
+    /// adapter: `copilot --acp --stdio`. Model and reasoning effort are
+    /// server-level flags there, so they are set at spawn rather than
+    /// negotiated per session.
+    Copilot,
+    /// A `{name}-acp` adapter. Nothing can be assumed about its flags, so it is
+    /// spawned bare and takes whatever defaults its own config gives it.
+    Adapter,
+}
+
 /// How to launch a resolved agent.
 #[derive(Debug, Clone, serde::Serialize)]
 #[serde(tag = "mode", rename_all = "camelCase")]
@@ -22,7 +38,7 @@ pub enum AgentLaunch {
     /// Spawn via CLI print mode. Uses the user's subscription.
     Cli { binary: String, kind: AgentKind },
     /// Spawn as an ACP subprocess. Requires API key or its own auth.
-    Acp { binary: String },
+    Acp { binary: String, kind: AcpKind },
 }
 
 /// Resolve an MCP client name to a launch config.
@@ -46,16 +62,31 @@ pub fn resolve_agent_binary(client_name: &str) -> Option<AgentLaunch> {
                 });
             }
         }
+        // Copilot CLI identifies itself over MCP as `github-copilot-developer`,
+        // a name it shares with every other Copilot host (VS Code included), so
+        // that handshake can only ever mean "some Copilot" — resolving it to the
+        // CLI is right precisely because the CLI is the only one we can spawn.
+        "copilot" | "copilot-cli" | "github-copilot" | "github-copilot-developer" => {
+            if let Some(launch) = copilot_launch() {
+                return Some(launch);
+            }
+        }
         _ => {}
     }
 
     // Try ACP adapter binary: "{name}-acp" or the name itself
     let acp_name = format!("{}-acp", client_name.replace(' ', "-"));
     if let Ok(path) = which::which(&acp_name) {
-        return Some(AgentLaunch::Acp { binary: path.to_string_lossy().to_string() });
+        return Some(AgentLaunch::Acp {
+            binary: path.to_string_lossy().to_string(),
+            kind: AcpKind::Adapter,
+        });
     }
     if let Ok(path) = which::which(client_name) {
-        return Some(AgentLaunch::Acp { binary: path.to_string_lossy().to_string() });
+        return Some(AgentLaunch::Acp {
+            binary: path.to_string_lossy().to_string(),
+            kind: AcpKind::Adapter,
+        });
     }
 
     None
@@ -75,14 +106,30 @@ fn codex_launch() -> Option<AgentLaunch> {
     })
 }
 
+/// Copilot CLI runs in ACP mode rather than print mode. Its `-p` mode would
+/// work, but ACP is the better fit: the MCP server rides the session request,
+/// which sidesteps Copilot skipping a project's `.mcp.json` in untrusted
+/// folders, and the protocol reports tool calls as structured updates instead
+/// of leaving the activity readout to parse a text stream.
+fn copilot_launch() -> Option<AgentLaunch> {
+    which::which("copilot").ok().map(|path| AgentLaunch::Acp {
+        binary: path.to_string_lossy().to_string(),
+        kind: AcpKind::Copilot,
+    })
+}
+
 /// Detect an available agent honoring a user preference. The preferred agent is
-/// tried first; if it isn't on PATH we fall back to the other so a fill still
-/// runs. `pref` is "auto" | "claudeCode" | "codex".
+/// tried first; if it isn't on PATH we fall back to the others so a fill still
+/// runs. `pref` is "auto" | "claudeCode" | "codex" | "copilot".
 pub fn detect_available_agent_pref(pref: &str) -> Option<AgentLaunch> {
+    // Fallback order is the same everywhere — preference first, then the rest in
+    // a fixed order — so "my agent isn't installed" degrades predictably.
+    let others = || claude_launch().or_else(codex_launch).or_else(copilot_launch);
     match pref {
-        "codex" => codex_launch().or_else(claude_launch),
-        "claudeCode" => claude_launch().or_else(codex_launch),
-        _ => claude_launch().or_else(codex_launch),
+        "codex" => codex_launch().or_else(others),
+        "claudeCode" => claude_launch().or_else(others),
+        "copilot" => copilot_launch().or_else(others),
+        _ => others(),
     }
 }
 

--- a/crates/scryer-acp/src/runtime.rs
+++ b/crates/scryer-acp/src/runtime.rs
@@ -10,7 +10,7 @@ use tokio_util::compat::{TokioAsyncReadCompatExt, TokioAsyncWriteCompatExt};
 
 use crate::client::ScryerClient;
 use crate::events::{AgentEvent, Usage};
-use crate::AgentKind;
+use crate::{AcpKind, AgentKind};
 
 /// How the agent should be launched.
 #[derive(Clone)]
@@ -18,7 +18,7 @@ pub enum LaunchMode {
     /// CLI print mode. Uses the user's subscription.
     Cli { kind: AgentKind },
     /// ACP subprocess.
-    Acp,
+    Acp { kind: AcpKind },
 }
 
 /// Commands sent to the runtime.
@@ -159,8 +159,8 @@ fn runtime_thread(
                             &agent_binary, &kind, &cwd, &model_name, &effort, &mcp_binary,
                             &prompt, &tool_refs, id, event_tx, done_tx.clone(),
                         ),
-                        LaunchMode::Acp => start_acp_session(
-                            &agent_binary, &cwd, &model_name, &mcp_binary,
+                        LaunchMode::Acp { kind } => start_acp_session(
+                            &agent_binary, &kind, &cwd, &model_name, &effort, &mcp_binary,
                             &prompt, id, event_tx, done_tx.clone(),
                         ).await,
                     };
@@ -538,10 +538,81 @@ fn summarize_event(line: &str) -> Option<String> {
 // ACP mode: full protocol handshake
 // ---------------------------------------------------------------------------
 
+/// The command line an ACP subprocess is spawned with. The protocol carries the
+/// session — cwd, MCP servers, the prompt — but not which model or how hard to
+/// think, so for a dialect that takes those as process flags they belong here.
+fn acp_args(kind: &AcpKind, model_name: &str, effort: &str) -> Vec<String> {
+    match kind {
+        AcpKind::Copilot => {
+            let mut args = vec!["--acp".to_string(), "--stdio".to_string()];
+            if !model_name.is_empty() {
+                args.push("--model".into());
+                args.push(model_name.to_string());
+            }
+            if !effort.is_empty() {
+                args.push("--effort".into());
+                args.push(effort.to_string());
+            }
+            args
+        }
+        // Nothing is known about an adapter's flags, so it gets none: its own
+        // config decides the model, exactly as it does outside scryer.
+        AcpKind::Adapter => Vec::new(),
+    }
+}
+
+/// Does this project's MCP config declare scryer? The question only arises for
+/// an agent that won't take a server over the protocol, so the config on disk
+/// is the only route in — checking it turns "the agent said it has no scryer
+/// tool" into a message that names what to fix. Both files Copilot reads count.
+fn project_declares_scryer_mcp(cwd: &str) -> bool {
+    let root = std::path::Path::new(cwd);
+    [root.join(".mcp.json"), root.join(".github").join("mcp.json")]
+        .iter()
+        .any(|p| {
+            std::fs::read_to_string(p)
+                .ok()
+                .and_then(|s| serde_json::from_str::<serde_json::Value>(&s).ok())
+                .is_some_and(|v| v.pointer("/mcpServers/scryer").is_some())
+        })
+}
+
+#[cfg(test)]
+mod acp_args_tests {
+    use super::*;
+
+    /// Copilot serves ACP from its own binary, so the mode flags are mandatory
+    /// and model/effort ride along as process flags. An empty model or effort
+    /// means "whatever the CLI is already set to" and must not be passed as an
+    /// empty string, which Copilot rejects as an unknown model.
+    #[test]
+    fn copilot_gets_its_mode_flags_and_only_the_settings_that_are_set() {
+        assert_eq!(
+            acp_args(&AcpKind::Copilot, "gpt-5.5", "high"),
+            ["--acp", "--stdio", "--model", "gpt-5.5", "--effort", "high"]
+        );
+        assert_eq!(acp_args(&AcpKind::Copilot, "", ""), ["--acp", "--stdio"]);
+        assert_eq!(
+            acp_args(&AcpKind::Copilot, "", "medium"),
+            ["--acp", "--stdio", "--effort", "medium"]
+        );
+    }
+
+    /// An adapter binary is spawned bare: nothing is known about its flags, so
+    /// inventing any would be a guess that fails at spawn.
+    #[test]
+    fn an_adapter_is_spawned_with_no_flags() {
+        assert!(acp_args(&AcpKind::Adapter, "gpt-5.5", "high").is_empty());
+    }
+}
+
+#[allow(clippy::too_many_arguments)]
 async fn start_acp_session(
     agent_binary: &str,
+    kind: &AcpKind,
     cwd: &str,
-    _model_name: &str,
+    model_name: &str,
+    effort: &str,
     mcp_binary: &str,
     prompt: &str,
     id: u64,
@@ -549,15 +620,40 @@ async fn start_acp_session(
     done_tx: mpsc::UnboundedSender<RuntimeCommand>,
 ) -> Result<oneshot::Sender<()>, String> {
     let mut child = tokio::process::Command::new(agent_binary)
+        .args(acp_args(kind, model_name, effort))
+        .current_dir(cwd)
         .stdin(std::process::Stdio::piped())
         .stdout(std::process::Stdio::piped())
-        .stderr(std::process::Stdio::null())
+        .stderr(std::process::Stdio::piped())
         .kill_on_drop(true)
         .spawn()
         .map_err(|e| format!("Failed to spawn {agent_binary}: {e}"))?;
 
     let stdin = child.stdin.take().ok_or("No stdin on child")?;
     let stdout = child.stdout.take().ok_or("No stdout on child")?;
+
+    // ACP carries no channel for an agent's own diagnostics, and stdout is the
+    // protocol — so when one of these subprocesses dies, everything it said
+    // about why went to stderr. Tee it to the same place CLI sessions log to,
+    // or a failure surfaces as nothing more useful than "server shut down".
+    if let Some(stderr) = child.stderr.take() {
+        let log_path = std::path::Path::new(cwd)
+            .join(".scryer")
+            .join("build-logs")
+            .join(format!("session-{id}.err.log"));
+        let _ = std::fs::create_dir_all(log_path.parent().unwrap());
+        tokio::task::spawn_local(async move {
+            use std::io::Write as _;
+            use tokio::io::{AsyncBufReadExt, BufReader};
+            let mut log = std::fs::File::create(&log_path).ok();
+            let mut lines = BufReader::new(stderr).lines();
+            while let Ok(Some(line)) = lines.next_line().await {
+                if let Some(f) = log.as_mut() {
+                    let _ = writeln!(f, "{line}");
+                }
+            }
+        });
+    }
 
     let client = ScryerClient::new(event_tx.clone());
 
@@ -581,19 +677,44 @@ async fn start_acp_session(
         .await
         .map_err(|e| format!("ACP initialize failed: {e}"))?;
 
-    let mcp_server = McpServer::Stdio(McpServerStdio::new("scryer", mcp_binary));
+    // Hand the session the scryer MCP server — except where the agent has told
+    // us it can't take one this way. Copilot's ACP advertises `http` and `sse`
+    // MCP transports and no stdio, and true to that it accepts a stdio entry
+    // here without complaint and then ignores it, leaving the session with no
+    // scryer tools at all. It does read the project's own `.mcp.json`, which is
+    // the file scryer already writes, so there the config on disk is the route
+    // in — and folder trust becomes a prerequisite for the launch path too, not
+    // just for hooks.
+    let mcp_servers = match kind {
+        AcpKind::Copilot => {
+            if !project_declares_scryer_mcp(cwd) {
+                return Err(format!(
+                    "Copilot can only reach scryer through this project's own MCP config, and \
+                     {cwd}/.mcp.json doesn't declare it. Enable AI tool integration for this \
+                     project (or run `scryer-mcp init`), and make sure you've trusted the folder \
+                     in Copilot — it skips project MCP servers in untrusted folders."
+                ));
+            }
+            Vec::new()
+        }
+        AcpKind::Adapter => vec![McpServer::Stdio(McpServerStdio::new("scryer", mcp_binary))],
+    };
     let session = connection
-        .new_session(
-            NewSessionRequest::new(PathBuf::from(cwd)).mcp_servers(vec![mcp_server]),
-        )
+        .new_session(NewSessionRequest::new(PathBuf::from(cwd)).mcp_servers(mcp_servers))
         .await
         .map_err(|e| format!("ACP new_session failed: {e}"))?;
 
     let (cancel_tx, cancel_rx) = oneshot::channel::<()>();
     let prompt_text = prompt.to_string();
     let sid = session.session_id.clone();
+    let child_pid = child.id();
 
     tokio::task::spawn_local(async move {
+        // `child` is owned by this task for the life of the session. It was
+        // spawned `kill_on_drop`, so leaving it in the starting frame killed the
+        // agent the moment the session was handed back — the whole ACP path
+        // died between `session/new` and the first prompt.
+        let mut child = child;
         let prompt_fut = connection.prompt(PromptRequest::new(
             sid.clone(),
             vec![prompt_text.into()],
@@ -621,10 +742,15 @@ async fn start_acp_session(
                 }
             }
             _ = cancel_rx => {
+                // Ask politely over the protocol first, then make sure: an
+                // agent that ignores the notification would otherwise outlive
+                // the session it was cancelled out of.
                 let _ = connection.cancel(CancelNotification::new(sid)).await;
+                kill_process_tree(&mut child, child_pid).await;
                 let _ = event_tx.send(AgentEvent::Cancelled);
             }
         }
+        drop(child); // ends the agent process for a completed session too
         let _ = done_tx.send(RuntimeCommand::Done { id });
     });
 

--- a/crates/scryer-core/src/settings.rs
+++ b/crates/scryer-core/src/settings.rs
@@ -14,7 +14,8 @@ pub fn global_dir() -> PathBuf {
 
 /// Per-agent model + reasoning effort. An empty model means "use the agent
 /// CLI's own default". Effort values are agent-specific (Claude accepts
-/// low/medium/high/xhigh/max; Codex accepts minimal/low/medium/high).
+/// low/medium/high/xhigh/max; Codex accepts minimal/low/medium/high; Copilot
+/// accepts none/low/medium/high/xhigh/max).
 #[derive(Debug, Clone, Serialize, Deserialize)]
 #[serde(rename_all = "camelCase")]
 pub struct AgentSettings {
@@ -39,13 +40,15 @@ impl Default for AgentSettings {
 #[derive(Debug, Clone, Serialize, Deserialize)]
 #[serde(rename_all = "camelCase")]
 pub struct SubagentSettings {
-    /// Which agent to launch: "auto" | "claudeCode" | "codex".
+    /// Which agent to launch: "auto" | "claudeCode" | "codex" | "copilot".
     #[serde(default = "default_agent")]
     pub agent: String,
     #[serde(default)]
     pub claude: AgentSettings,
     #[serde(default)]
     pub codex: AgentSettings,
+    #[serde(default)]
+    pub copilot: AgentSettings,
     /// Confirm before any UI action launches an agent (a billable run). Lets the
     /// user see which agent + model + effort will run; "don't ask again" clears
     /// it. Defaults to true so the gate is opt-out, not opt-in.
@@ -59,6 +62,7 @@ impl Default for SubagentSettings {
             agent: default_agent(),
             claude: AgentSettings::default(),
             codex: AgentSettings::default(),
+            copilot: AgentSettings::default(),
             confirm_launch: default_confirm_launch(),
         }
     }

--- a/crates/scryer-mcp/src/hook_client.rs
+++ b/crates/scryer-mcp/src/hook_client.rs
@@ -1,21 +1,26 @@
-//! `scryer-mcp hook` — the session-hook client for Claude Code and Codex.
+//! `scryer-mcp hook` — the session-hook client for Claude Code, Codex and
+//! Copilot CLI.
 //!
 //! The harness invokes this once per hook event with the event JSON on stdin.
-//! Both harnesses use the same field names and output schema, so one client
-//! serves both, dispatching on the event and tool names. It bridges the event
-//! to the desktop app's loopback endpoint (advertised in `.scryer/hook.json`
-//! while the app has the project open):
+//! All three name the event fields the same way — `hook_event_name`,
+//! `session_id`, `cwd`, `tool_name`, `tool_input` — so one client serves them
+//! all, dispatching on the event and tool names. It bridges the event to the
+//! desktop app's loopback endpoint (advertised in `.scryer/hook.json` while the
+//! app has the project open):
 //!
 //! - SessionStart      → GET /status   → inject the model's status line
-//! - PostToolUse Read  → GET /overlay  → inject the file's governing intent
-//! - PostToolUse Edit… → POST /touch   → record the touch, say nothing
+//! - PostToolUse read  → GET /overlay  → inject the file's governing intent
+//! - PostToolUse edit… → POST /touch   → record the touch, say nothing
 //! - Stop              → GET /close    → block once with unreconciled claims
 //!
-//! Codex names its tools differently — edits arrive as `apply_patch` (or a
-//! Bash `apply_patch` heredoc) carrying a patch envelope instead of a file
-//! path, and reads fire no hooks at all — so there the overlay rides
-//! PreToolUse on the patch (intent lands just before the edit) and touches
-//! are recorded per file named in the envelope.
+//! Where they differ is the tool vocabulary and the reply shape, and neither is
+//! discoverable from the event — so the install writes which harness it is
+//! (`--copilot`) rather than the client sniffing for it. See [`Harness`].
+//!
+//! Codex reads fire no hooks at all, so there the overlay rides PreToolUse on
+//! the patch (intent lands just before the edit) and touches are recorded per
+//! file named in the envelope. Copilot fires post-read like Claude Code does,
+//! so it gets the same post-Read overlay.
 //!
 //! Every failure path — no discovery file, endpoint gone, malformed input —
 //! exits 0 with no output: installed hooks are inert unless the Scryer app is
@@ -30,7 +35,79 @@ use std::path::{Path, PathBuf};
 const READ_TIMEOUT: std::time::Duration = std::time::Duration::from_secs(8);
 const CONNECT_TIMEOUT: std::time::Duration = std::time::Duration::from_millis(300);
 
-pub fn run_hook_client() -> Result<(), Box<dyn std::error::Error>> {
+/// Which harness registered this hook. The event JSON is the same shape
+/// everywhere, but two things about it are not, and neither can be read off the
+/// event:
+///
+/// - **Tool vocabulary.** Claude Code and Codex call the tools scryer cares
+///   about `Read` / `Edit` / `Write` / `apply_patch` / `Bash`, and name the
+///   edited file in `tool_input.file_path`. Copilot calls them `view` /
+///   `create` / `edit` / `str_replace_editor` / `apply_patch`, and names the
+///   file in `tool_input.path`.
+/// - **Where injected context goes.** Claude Code reads it out of the
+///   `hookSpecificOutput` envelope; Copilot reads a top-level
+///   `additionalContext` on SessionStart and PostToolUse (only its PreToolUse
+///   accepts either). One reply can't satisfy both without guessing.
+///
+/// So the install records the harness in the registered command — `hook` or
+/// `hook --copilot` — and the client is told rather than left to sniff.
+#[derive(Clone, Copy, PartialEq, Eq)]
+enum Harness {
+    /// Claude Code and Codex: same vocabulary, same envelope.
+    ClaudeLike,
+    Copilot,
+}
+
+/// What a tool call means to scryer, once the harness's own name for it is
+/// resolved. Everything else is [`ToolKind::Other`] and costs nothing.
+#[derive(PartialEq, Eq)]
+enum ToolKind {
+    /// Read a file — the moment to inject the intent governing it.
+    Read,
+    /// Write to the file named in the arguments.
+    Write,
+    /// Write to every file named in an `apply_patch` envelope.
+    Patch,
+    Other,
+}
+
+impl Harness {
+    fn tool_kind(self, tool: &str) -> ToolKind {
+        match (self, tool) {
+            (Harness::ClaudeLike, "Read") | (Harness::Copilot, "view") => ToolKind::Read,
+            (Harness::ClaudeLike, "Edit" | "Write" | "NotebookEdit") => ToolKind::Write,
+            (Harness::Copilot, "create" | "edit" | "str_replace_editor") => ToolKind::Write,
+            // Codex routes edits through a native `apply_patch` or a Bash
+            // heredoc wrapping the same envelope; Copilot has the native tool
+            // only. A Bash command with no envelope in it parses to no files
+            // and costs one no-op.
+            (Harness::ClaudeLike, "apply_patch" | "Bash") => ToolKind::Patch,
+            (Harness::Copilot, "apply_patch") => ToolKind::Patch,
+            _ => ToolKind::Other,
+        }
+    }
+
+    /// Emit injected context in the shape this harness reads.
+    fn emit_context(self, event_name: &str, text: &str) {
+        match self {
+            Harness::ClaudeLike => emit(&serde_json::json!({
+                "hookSpecificOutput": {
+                    "hookEventName": event_name,
+                    "additionalContext": text,
+                }
+            })),
+            Harness::Copilot => emit(&serde_json::json!({ "additionalContext": text })),
+        }
+    }
+}
+
+pub fn run_hook_client(args: &[String]) -> Result<(), Box<dyn std::error::Error>> {
+    let harness = if args.iter().any(|a| a == "--copilot") {
+        Harness::Copilot
+    } else {
+        Harness::ClaudeLike
+    };
+
     let mut input = String::new();
     if std::io::stdin().read_to_string(&mut input).is_err() {
         return Ok(());
@@ -44,9 +121,9 @@ pub fn run_hook_client() -> Result<(), Box<dyn std::error::Error>> {
     };
 
     match event["hook_event_name"].as_str().unwrap_or_default() {
-        "SessionStart" => session_start(&endpoint),
-        "PreToolUse" => pre_tool_use(&endpoint, &event),
-        "PostToolUse" => post_tool_use(&endpoint, &event),
+        "SessionStart" => session_start(&endpoint, harness),
+        "PreToolUse" => pre_tool_use(&endpoint, &event, harness),
+        "PostToolUse" => post_tool_use(&endpoint, &event, harness),
         "Stop" => stop(&endpoint, &event),
         _ => {}
     }
@@ -169,29 +246,33 @@ fn emit(v: &serde_json::Value) {
     println!("{}", serde_json::to_string(v).unwrap_or_default());
 }
 
-fn session_start(ep: &Endpoint) {
+fn session_start(ep: &Endpoint, harness: Harness) {
     let Some(status) = call(ep, "GET", "/status", "") else { return };
     let Some(line) = status["statusLine"].as_str() else { return };
-    // Harness-neutral wording: on Claude Code the overlay arrives as files are
-    // read, on Codex as they are edited — "work in" covers both truthfully.
+    // Harness-neutral wording: on Claude Code and Copilot the overlay arrives
+    // as files are read, on Codex as they are edited — "work in" covers all
+    // three truthfully.
     let context = format!(
         "{line}\nThe Scryer app is open on this project, so its architecture model is live and \
          binding. The claims and directives governing a file are injected automatically as you \
          work in it; `locate {{file}}` (MCP) answers on demand, `get_pending` lists \
          outstanding plan work."
     );
-    emit(&serde_json::json!({
-        "hookSpecificOutput": {
-            "hookEventName": "SessionStart",
-            "additionalContext": context,
-        }
-    }));
+    harness.emit_context("SessionStart", &context);
 }
 
-fn post_tool_use(ep: &Endpoint, event: &serde_json::Value) {
-    match event["tool_name"].as_str().unwrap_or_default() {
-        "Read" => {
-            let Some(file) = event["tool_input"]["file_path"].as_str() else { return };
+/// The file a tool call names. `file_path` is Claude Code's and Codex's key,
+/// `path` Copilot's; accepting both keeps one lookup for every harness.
+fn tool_file(event: &serde_json::Value) -> Option<&str> {
+    event["tool_input"]["file_path"]
+        .as_str()
+        .or_else(|| event["tool_input"]["path"].as_str())
+}
+
+fn post_tool_use(ep: &Endpoint, event: &serde_json::Value, harness: Harness) {
+    match harness.tool_kind(event["tool_name"].as_str().unwrap_or_default()) {
+        ToolKind::Read => {
+            let Some(file) = tool_file(event) else { return };
             let Some(overlay) = call(
                 ep,
                 "GET",
@@ -201,25 +282,19 @@ fn post_tool_use(ep: &Endpoint, event: &serde_json::Value) {
                 return;
             };
             if let Some(text) = render_overlay(&overlay) {
-                emit(&serde_json::json!({
-                    "hookSpecificOutput": {
-                        "hookEventName": "PostToolUse",
-                        "additionalContext": text,
-                    }
-                }));
+                harness.emit_context("PostToolUse", &text);
             }
         }
-        "Edit" | "Write" | "NotebookEdit" => {
-            let Some(file) = event["tool_input"]["file_path"].as_str() else { return };
+        ToolKind::Write => {
+            let Some(file) = tool_file(event) else { return };
             touch(ep, event, file);
         }
-        // Codex: edits carry a patch envelope, not a file_path.
-        "apply_patch" | "Bash" => {
+        ToolKind::Patch => {
             for file in patched_files(event) {
                 touch(ep, event, &file);
             }
         }
-        _ => {}
+        ToolKind::Other => {}
     }
 }
 
@@ -238,9 +313,10 @@ const OVERLAY_FILE_CAP: usize = 5;
 
 /// Codex reads fire no hook events, so the intent overlay rides the edit
 /// instead: just before a patch lands, inject the claims and directives
-/// governing the files it names. Claude Code never sends this event (scryer
-/// doesn't register PreToolUse there — post-Read is the better moment).
-fn pre_tool_use(ep: &Endpoint, event: &serde_json::Value) {
+/// governing the files it names. Claude Code and Copilot never send this event
+/// (scryer registers PreToolUse for neither — post-Read is the better moment,
+/// and both fire it).
+fn pre_tool_use(ep: &Endpoint, event: &serde_json::Value, harness: Harness) {
     let mut sections: Vec<String> = Vec::new();
     for file in patched_files(event).iter().take(OVERLAY_FILE_CAP) {
         let Some(overlay) = call(
@@ -258,22 +334,25 @@ fn pre_tool_use(ep: &Endpoint, event: &serde_json::Value) {
     if sections.is_empty() {
         return;
     }
-    emit(&serde_json::json!({
-        "hookSpecificOutput": {
-            "hookEventName": "PreToolUse",
-            "additionalContext": sections.join("\n\n"),
-        }
-    }));
+    harness.emit_context("PreToolUse", &sections.join("\n\n"));
 }
 
 /// File paths named by the apply_patch envelope in this tool call, if any.
-/// The native `apply_patch` tool carries the envelope in `tool_input.command`;
+/// Codex's native `apply_patch` carries the envelope in `tool_input.command`;
 /// newer Codex builds route edits through Bash as an `apply_patch <<'EOF'`
-/// heredoc with the same envelope inside, so both tools get the same parse.
-/// Envelope paths are cwd-relative — absolutized here so the endpoint's
-/// project-prefix stripping works even when the session runs in a subdirectory.
+/// heredoc with the same envelope inside; Copilot's `apply_patch` is a freeform
+/// tool whose whole `tool_input` IS the patch string. The envelope grammar is
+/// identical in all three, so the same parse serves them — only where to look
+/// for it differs, and trying the string form first covers that without needing
+/// to know the harness. Envelope paths are cwd-relative — absolutized here so
+/// the endpoint's project-prefix stripping works even when the session runs in
+/// a subdirectory.
 fn patched_files(event: &serde_json::Value) -> Vec<String> {
-    let command = event["tool_input"]["command"].as_str().unwrap_or_default();
+    let input = &event["tool_input"];
+    let command = input
+        .as_str()
+        .or_else(|| input["command"].as_str())
+        .unwrap_or_default();
     let cwd = event["cwd"].as_str().unwrap_or_default();
     envelope_files(command)
         .into_iter()

--- a/crates/scryer-mcp/src/main.rs
+++ b/crates/scryer-mcp/src/main.rs
@@ -58,11 +58,11 @@ async fn main() -> Result<(), Box<dyn std::error::Error>> {
     Ok(())
 }
 
-/// Write project-scoped MCP config files in the current directory so that
-/// Claude Code and/or Codex discover scryer-mcp when working in this project.
-/// Only writes config for tools that are actually installed. With
-/// `statusline`, also register the model's status one-liner as Claude Code's
-/// statusline (never clobbering a foreign one).
+/// Write project-scoped MCP config files in the current directory so that the
+/// installed agent CLIs discover scryer-mcp when working in this project. Only
+/// writes config for tools that are actually installed. With `statusline`, also
+/// register the model's status one-liner as Claude Code's statusline (never
+/// clobbering a foreign one).
 fn init_project(statusline: bool) -> Result<(), Box<dyn std::error::Error>> {
     let binary_path = std::env::current_exe()?
         .canonicalize()?
@@ -73,35 +73,39 @@ fn init_project(statusline: bool) -> Result<(), Box<dyn std::error::Error>> {
 
     let has_claude = which("claude");
     let has_codex = which("codex");
+    let has_copilot = which("copilot");
 
-    if !has_claude && !has_codex {
-        eprintln!("Neither `claude` nor `codex` found in PATH.");
-        eprintln!("Install Claude Code or OpenAI Codex first, then re-run `scryer-mcp init`.");
+    if !has_claude && !has_codex && !has_copilot {
+        eprintln!("None of `claude`, `codex` or `copilot` found in PATH.");
+        eprintln!("Install Claude Code, OpenAI Codex or GitHub Copilot CLI first, then re-run `scryer-mcp init`.");
         std::process::exit(1);
     }
 
     let mut wrote_any = false;
 
-    if has_claude {
-        init_claude_code(&cwd, &binary_path)?;
-        if statusline {
-            match cli::install_statusline(&cwd, &binary_path)? {
-                cli::StatuslineInstall::Installed(path) => {
-                    eprintln!("Registered the scryer statusline in {}", path.display());
-                }
-                // statusLine is a single slot (whole-line replacement), so a
-                // foreign entry is composed with by hand, never clobbered.
-                cli::StatuslineInstall::ForeignExists(path) => {
-                    eprintln!(
-                        "A statusLine is already configured in {} — left untouched.",
-                        path.display()
-                    );
-                    eprintln!("To add scryer to it, append this to your statusline script's output:");
-                    eprintln!("  \"{binary_path}\" statusline");
-                }
+    // One `.mcp.json` serves both Claude Code and Copilot CLI — they read the
+    // same file, so this is written once when either is installed.
+    if has_claude || has_copilot {
+        init_mcp_json(&cwd, &binary_path)?;
+        wrote_any = true;
+    }
+
+    if has_claude && statusline {
+        match cli::install_statusline(&cwd, &binary_path)? {
+            cli::StatuslineInstall::Installed(path) => {
+                eprintln!("Registered the scryer statusline in {}", path.display());
+            }
+            // statusLine is a single slot (whole-line replacement), so a
+            // foreign entry is composed with by hand, never clobbered.
+            cli::StatuslineInstall::ForeignExists(path) => {
+                eprintln!(
+                    "A statusLine is already configured in {} — left untouched.",
+                    path.display()
+                );
+                eprintln!("To add scryer to it, append this to your statusline script's output:");
+                eprintln!("  \"{binary_path}\" statusline");
             }
         }
-        wrote_any = true;
     } else if statusline {
         eprintln!("--statusline is a Claude Code integration; `claude` was not found in PATH.");
     }
@@ -115,6 +119,7 @@ fn init_project(statusline: bool) -> Result<(), Box<dyn std::error::Error>> {
         let tools: Vec<&str> = [
             if has_claude { Some("Claude Code") } else { None },
             if has_codex { Some("Codex") } else { None },
+            if has_copilot { Some("Copilot CLI") } else { None },
         ].into_iter().flatten().collect();
         eprintln!("\nDone. {} will use scryer in this project.", tools.join(" and "));
         if has_claude {
@@ -141,8 +146,12 @@ fn which(name: &str) -> bool {
         .unwrap_or(false)
 }
 
-/// Write .mcp.json for Claude Code, merging with any existing config.
-fn init_claude_code(
+/// Write `.mcp.json`, merging with any existing config. Both Claude Code and
+/// Copilot CLI read this one file, so it is written once for either. Copilot
+/// treats `"stdio"` as an alias of its own `"local"` type and defaults an entry
+/// with no `tools` key to every tool, so the Claude-shaped entry serves both
+/// verbatim.
+fn init_mcp_json(
     cwd: &std::path::Path,
     binary_path: &str,
 ) -> Result<(), Box<dyn std::error::Error>> {

--- a/crates/scryer-mcp/src/main.rs
+++ b/crates/scryer-mcp/src/main.rs
@@ -31,9 +31,14 @@ async fn main() -> Result<(), Box<dyn std::error::Error>> {
             }
             return init_project(statusline);
         }
-        // Claude Code session hook: event JSON on stdin, hook JSON on stdout.
+        // Agent session hook: event JSON on stdin, hook JSON on stdout. Takes
+        // `--copilot` because Copilot's tool names and reply shape differ and
+        // the event can't be sniffed for them — the install writes the flag.
         // Silent no-op unless the Scryer app has this project open.
-        Some("hook") => return hook_client::run_hook_client(),
+        Some("hook") => {
+            let args: Vec<String> = std::env::args().skip(2).collect();
+            return hook_client::run_hook_client(&args);
+        }
         // Loop-state one-liner for humans, straight from disk (no app needed).
         Some("status") => {
             let args: Vec<String> = std::env::args().skip(2).collect();

--- a/demo/tauri-stub.ts
+++ b/demo/tauri-stub.ts
@@ -35,6 +35,7 @@ export async function invoke<T = unknown>(cmd: string, args?: unknown): Promise<
       agent: "claudeCode",
       claude: { model: "claude-opus-4-8", effort: "high" },
       codex: { model: "", effort: "medium" },
+      copilot: { model: "", effort: "medium" },
       confirmLaunch: false,
     } as T;
   }

--- a/demo/tauri-stub.ts
+++ b/demo/tauri-stub.ts
@@ -29,7 +29,7 @@ export async function invoke<T = unknown>(cmd: string, args?: unknown): Promise<
   // reads. Serve a real Claude Code · opus · high setup so the lifted ProjectPicker
   // and Powerline show an authentic launch — and `confirmLaunch: false` so the
   // prologue's "Generate" fires straight into the build with no modal.
-  if (cmd === "detect_ai_tools") return { claude: true, codex: false } as T;
+  if (cmd === "detect_ai_tools") return { claude: true, codex: false, copilot: false } as T;
   if (cmd === "get_subagent_settings") {
     return {
       agent: "claudeCode",

--- a/shell.nix
+++ b/shell.nix
@@ -1,7 +1,18 @@
 { pkgs ? import <nixpkgs> {} }:
 
+let
+  # Copilot CLI, for exercising scryer's Copilot integration (hook payloads, the
+  # ACP handshake) against the real binary rather than the docs. It is an unfree
+  # package, so it joins the shell only where unfree is already permitted —
+  # either in the caller's nixpkgs config or via NIXPKGS_ALLOW_UNFREE=1. Nobody's
+  # license stance gets decided for them, and a contributor who hasn't opted in
+  # still gets a working shell, just without the Copilot integration tests.
+  # Claude Code and Codex are installed out-of-band; only this one is packaged.
+  unfreeOk = (pkgs.config.allowUnfree or false) || builtins.getEnv "NIXPKGS_ALLOW_UNFREE" == "1";
+  copilot = pkgs.lib.optional unfreeOk pkgs.github-copilot-cli;
+in
 pkgs.mkShell {
-  buildInputs = with pkgs; [
+  buildInputs = (with pkgs; [
     # Node
     nodejs
     pnpm
@@ -32,7 +43,7 @@ pkgs.mkShell {
     pango
     gdk-pixbuf
     atk
-  ];
+  ]) ++ copilot;
 
   shellHook = ''
     export GIO_MODULE_DIR="${pkgs.glib-networking}/lib/gio/modules"
@@ -42,5 +53,7 @@ pkgs.mkShell {
     # (missing libglib etc). Skip the download and drive the Nix-built chromium.
     export PLAYWRIGHT_SKIP_BROWSER_DOWNLOAD=1
     export PLAYWRIGHT_CHROMIUM_EXECUTABLE="${pkgs.chromium}/bin/chromium"
-  '';
+${pkgs.lib.optionalString (!unfreeOk) ''
+    echo "note: copilot (unfree) left out of this shell — re-enter with NIXPKGS_ALLOW_UNFREE=1 to test the Copilot integration."
+''}  '';
 }

--- a/src-tauri/src/build.rs
+++ b/src-tauri/src/build.rs
@@ -292,14 +292,14 @@ pub(crate) async fn start_model_build(
     let mcp_binary = find_scryer_mcp().ok_or("scryer-mcp binary not found")?;
     let settings = scryer_core::read_subagent_settings();
     let launch = scryer_acp::detect_available_agent_pref(&settings.agent)
-        .ok_or("No AI agent found. Install Claude Code or Codex first.")?;
+        .ok_or("No AI agent found. Install Claude Code, Codex or Copilot CLI first.")?;
     let (model_name, effort) = config_for_launch(&settings, &launch);
     let (agent_binary, mode) = match launch {
         scryer_acp::AgentLaunch::Cli { binary, kind } => {
             (binary, scryer_acp::runtime::LaunchMode::Cli { kind })
         }
-        scryer_acp::AgentLaunch::Acp { binary } => {
-            (binary, scryer_acp::runtime::LaunchMode::Acp)
+        scryer_acp::AgentLaunch::Acp { binary, kind } => {
+            (binary, scryer_acp::runtime::LaunchMode::Acp { kind })
         }
     };
 
@@ -828,14 +828,14 @@ pub(crate) async fn start_drift_check(
     let mcp_binary = find_scryer_mcp().ok_or("scryer-mcp binary not found")?;
     let settings = scryer_core::read_subagent_settings();
     let launch = scryer_acp::detect_available_agent_pref(&settings.agent)
-        .ok_or("No AI agent found. Install Claude Code or Codex first.")?;
+        .ok_or("No AI agent found. Install Claude Code, Codex or Copilot CLI first.")?;
     let (model_name, effort) = config_for_launch(&settings, &launch);
     let (agent_binary, mode) = match launch {
         scryer_acp::AgentLaunch::Cli { binary, kind } => {
             (binary, scryer_acp::runtime::LaunchMode::Cli { kind })
         }
-        scryer_acp::AgentLaunch::Acp { binary } => {
-            (binary, scryer_acp::runtime::LaunchMode::Acp)
+        scryer_acp::AgentLaunch::Acp { binary, kind } => {
+            (binary, scryer_acp::runtime::LaunchMode::Acp { kind })
         }
     };
     let runtime = {

--- a/src-tauri/src/hooks.rs
+++ b/src-tauri/src/hooks.rs
@@ -42,9 +42,27 @@ impl Drop for InflightGuard {
 /// a stale run's touches age out.
 const TOUCH_TTL: Duration = Duration::from_secs(2 * 3600);
 
-/// Drop touches older than [`TOUCH_TTL`].
-fn prune_touches(log: &mut Vec<(Instant, Touch)>, now: Instant) {
-    log.retain(|(at, _)| now.saturating_duration_since(*at) < TOUCH_TTL);
+/// Everything the endpoint remembers about live sessions, behind one lock.
+#[derive(Default)]
+struct SessionLog {
+    /// Files each session has edited, with when — see [`TOUCH_TTL`].
+    touches: Vec<(Instant, Touch)>,
+    /// Sessions already handed a close gate. The gate fires ONCE per session:
+    /// its whole point is to make the agent look at claims it touched, and the
+    /// verdict may legitimately be "the claim still describes the code" — which
+    /// writes nothing, so a re-derived gate would fire again on the next stop,
+    /// forever. Claude Code's `stop_hook_active` flag guards its own side of
+    /// that, but Copilot sends no such flag, so the promise has to be kept
+    /// here, where the session is already known, rather than per harness.
+    gated: Vec<(Instant, String)>,
+}
+
+/// Drop touches and close-gate marks older than [`TOUCH_TTL`].
+fn prune_touches(log: &mut SessionLog, now: Instant) {
+    log.touches
+        .retain(|(at, _)| now.saturating_duration_since(*at) < TOUCH_TTL);
+    log.gated
+        .retain(|(at, _)| now.saturating_duration_since(*at) < TOUCH_TTL);
 }
 
 /// Managed Tauri state: the endpoint for the currently open project, if any.
@@ -129,7 +147,7 @@ pub fn start(
     .map_err(|e| e.to_string())?;
 
     let shutdown = Arc::new(AtomicBool::new(false));
-    let touches: Arc<Mutex<Vec<(Instant, Touch)>>> = Arc::new(Mutex::new(Vec::new()));
+    let touches: Arc<Mutex<SessionLog>> = Arc::new(Mutex::new(SessionLog::default()));
     // Shared across the accept loop and every worker thread it spawns.
     let project = Arc::new(project.to_path_buf());
     let token = Arc::new(token);
@@ -183,7 +201,7 @@ fn handle_request(
     mut stream: std::net::TcpStream,
     project: &Path,
     token: &str,
-    touches: &Arc<Mutex<Vec<(Instant, Touch)>>>,
+    touches: &Arc<Mutex<SessionLog>>,
     on_touch: &(impl Fn(&Touch) + Send + 'static),
 ) {
     let _ = stream.set_read_timeout(Some(std::time::Duration::from_secs(2)));
@@ -294,23 +312,43 @@ fn handle_request(
             let now = Instant::now();
             let mut log = touches.lock().unwrap();
             prune_touches(&mut log, now);
-            if !log.iter().any(|(_, t)| t == &touch) {
+            if !log.touches.iter().any(|(_, t)| t == &touch) {
                 on_touch(&touch);
-                log.push((now, touch));
+                log.touches.push((now, touch));
             }
-            respond(&mut stream, 200, &serde_json::json!({ "recorded": log.len() }));
+            respond(&mut stream, 200, &serde_json::json!({ "recorded": log.touches.len() }));
         }
         ("GET", "/close") => {
             let session = param("session").unwrap_or_default();
+            let now = Instant::now();
             let mut log = touches.lock().unwrap();
-            prune_touches(&mut log, Instant::now());
+            prune_touches(&mut log, now);
+            // Already gated once — say nothing, and skip the model read the
+            // answer would need. The session was told what to reconcile; a
+            // second gate on the same touches would be a loop, not a reminder.
+            if log.gated.iter().any(|(_, s)| *s == session) {
+                drop(log);
+                respond(&mut stream, 200, &empty_close_payload());
+                return;
+            }
             let touched: Vec<Touch> = log
+                .touches
                 .iter()
                 .filter(|(_, t)| session.is_empty() || t.session == session)
                 .map(|(_, t)| t.clone())
                 .collect();
             drop(log);
-            respond(&mut stream, 200, &close_payload(project, &touched));
+
+            let payload = close_payload(project, &touched);
+            // Only a gate that actually fires burns the session's one shot: a
+            // clean close leaves it armed for the edits still to come.
+            if payload["needsReconcile"]
+                .as_array()
+                .is_some_and(|n| !n.is_empty())
+            {
+                touches.lock().unwrap().gated.push((now, session));
+            }
+            respond(&mut stream, 200, &payload);
         }
         _ => respond(
             &mut stream,
@@ -468,6 +506,16 @@ fn status_payload(project: &Path) -> Result<serde_json::Value, String> {
 /// The fingerprint check compares against the last reconcile baseline, so a
 /// long-unreconciled file may surface pre-session changes too — still the
 /// right call: the claim needs a look and this session just worked there.
+/// The close view for a session that has nothing to answer for — same shape as
+/// [`close_payload`], reached without a model read.
+fn empty_close_payload() -> serde_json::Value {
+    serde_json::json!({
+        "needsReconcile": [],
+        "cleanModeled": [],
+        "unmodeled": [],
+    })
+}
+
 fn close_payload(project: &Path, touched: &[Touch]) -> serde_json::Value {
     let r = scryer_core::ModelRef::ProjectLocal(project.to_path_buf());
 
@@ -668,18 +716,24 @@ mod tests {
     }
 
     /// Touches older than the TTL are pruned; fresh ones survive — a resumed
-    /// session must not re-gate on a prior run's hours-old edits.
+    /// session must not re-gate on a prior run's hours-old edits. The same
+    /// applies to the gate marks: a session id resurfacing hours later is a new
+    /// run, and it gets its one gate back.
     #[test]
     fn prune_drops_only_stale_touches() {
         let now = Instant::now();
+        let stale = now.checked_sub(TOUCH_TTL + Duration::from_secs(60)).unwrap();
+        let fresh = now.checked_sub(Duration::from_secs(60)).unwrap();
         let touch = |f: &str| Touch { session: "s".into(), file: f.into(), symbol: None };
-        let mut log = vec![
-            (now.checked_sub(TOUCH_TTL + Duration::from_secs(60)).unwrap(), touch("old.rs")),
-            (now.checked_sub(Duration::from_secs(60)).unwrap(), touch("fresh.rs")),
-        ];
+        let mut log = SessionLog {
+            touches: vec![(stale, touch("old.rs")), (fresh, touch("fresh.rs"))],
+            gated: vec![(stale, "old-session".into()), (fresh, "live-session".into())],
+        };
         prune_touches(&mut log, now);
-        assert_eq!(log.len(), 1);
-        assert_eq!(log[0].1.file, "fresh.rs");
+        assert_eq!(log.touches.len(), 1);
+        assert_eq!(log.touches[0].1.file, "fresh.rs");
+        assert_eq!(log.gated.len(), 1);
+        assert_eq!(log.gated[0].1, "live-session");
     }
 
     /// System > Container with a claim anchored in src/auth.rs.
@@ -806,9 +860,10 @@ mod tests {
 
     /// With a reconcile baseline in place, /close gates on the anchor
     /// fingerprints: editing the anchored symbol puts the claim in
-    /// needsReconcile; editing around it leaves the file cleanModeled.
+    /// needsReconcile; editing around it leaves the file cleanModeled. And a
+    /// gate that fires is spent — see the tail of the test.
     #[test]
-    fn close_gates_on_anchor_fingerprints() {
+    fn close_gates_on_anchor_fingerprints_once_per_session() {
         let (dir, _) = temp_project();
         let root = dir.path();
         std::fs::create_dir_all(root.join("src")).unwrap();
@@ -863,6 +918,28 @@ mod tests {
         assert_eq!(claim["id"], "r-1");
         assert_eq!(claim["statement"], "serves requests");
         assert_eq!(claim["state"], "changed");
+
+        // That gate is now spent. The code is still out of sync — a session
+        // may legitimately answer "the claim still describes it" and write
+        // nothing — so re-deriving the gate would block the same session on
+        // every stop, forever. Only Claude Code carries a `stop_hook_active`
+        // flag to break that; the guarantee has to hold without one.
+        let (_, again) = request(server.port, &token, "GET", "/close?session=s1", "");
+        assert!(
+            again["needsReconcile"].as_array().unwrap().is_empty(),
+            "the gate fires once per session: {again}"
+        );
+
+        // A different session working the same file still gets its own gate.
+        request(
+            server.port,
+            &token,
+            "POST",
+            "/touch",
+            r#"{"session":"s2","file":"src/auth.rs"}"#,
+        );
+        let (_, other) = request(server.port, &token, "GET", "/close?session=s2", "");
+        assert_eq!(other["needsReconcile"][0]["file"], "src/auth.rs", "{other}");
     }
 
     /// A claim authored AND anchored during the session — living only in the

--- a/src-tauri/src/mcp_setup.rs
+++ b/src-tauri/src/mcp_setup.rs
@@ -2,8 +2,23 @@ use std::path::{Path, PathBuf};
 
 /// Check if a project has .mcp.json with a scryer entry.
 fn check_mcp_json(project_path: &str) -> bool {
-    let path = PathBuf::from(project_path).join(".mcp.json");
-    if let Ok(contents) = std::fs::read_to_string(&path) {
+    has_mcp_scryer_entry(&PathBuf::from(project_path).join(".mcp.json"))
+}
+
+/// Copilot reads the SAME `.mcp.json` Claude Code does — the one scryer already
+/// writes — so its MCP setup needs no file of its own. It also accepts a
+/// committed `.github/mcp.json`, which `.mcp.json` overrides; a project wired
+/// up by hand there is already set up, so detection honours both and the setup
+/// offer stays quiet. Omitting `tools` is fine: Copilot defaults a server to
+/// all tools, and it treats `"stdio"` as an alias of its own `"local"`.
+fn check_copilot_mcp(project_path: &str) -> bool {
+    let root = PathBuf::from(project_path);
+    has_mcp_scryer_entry(&root.join(".mcp.json"))
+        || has_mcp_scryer_entry(&root.join(".github").join("mcp.json"))
+}
+
+fn has_mcp_scryer_entry(path: &Path) -> bool {
+    if let Ok(contents) = std::fs::read_to_string(path) {
         if let Ok(root) = serde_json::from_str::<serde_json::Value>(&contents) {
             return root.pointer("/mcpServers/scryer").is_some();
         }
@@ -150,9 +165,11 @@ fn check_codex_toml(project_path: &str) -> bool {
 pub(crate) fn detect_ai_tools(project_path: Option<String>) -> serde_json::Value {
     let has_claude = which::which("claude").is_ok();
     let has_codex = which::which("codex").is_ok();
+    let has_copilot = which::which("copilot").is_ok();
 
     let claude_mcp = project_path.as_deref().map(check_mcp_json).unwrap_or(false);
     let codex_mcp = project_path.as_deref().map(check_codex_toml).unwrap_or(false);
+    let copilot_mcp = project_path.as_deref().map(check_copilot_mcp).unwrap_or(false);
     let claude_approved = project_path.as_deref().map(check_claude_approved).unwrap_or(false);
     let claude_hooks = project_path.as_deref().map(check_claude_hooks).unwrap_or(false);
     let codex_hooks = project_path.as_deref().map(check_codex_hooks).unwrap_or(false);
@@ -162,8 +179,10 @@ pub(crate) fn detect_ai_tools(project_path: Option<String>) -> serde_json::Value
     serde_json::json!({
         "claude": has_claude,
         "codex": has_codex,
+        "copilot": has_copilot,
         "claudeMcpEnabled": claude_mcp,
         "codexMcpEnabled": codex_mcp,
+        "copilotMcpEnabled": copilot_mcp,
         "claudeApproved": claude_approved,
         "claudeHooksEnabled": claude_hooks,
         "codexHooksEnabled": codex_hooks,

--- a/src-tauri/src/mcp_setup.rs
+++ b/src-tauri/src/mcp_setup.rs
@@ -73,15 +73,48 @@ const SCRYER_CODEX_HOOK_EVENTS: &[(&str, Option<&str>, u64)] = &[
     ("Stop", None, 15),
 ];
 
-/// Does this hook entry belong to scryer? Identified by the command invoking
-/// the scryer-mcp binary's `hook` subcommand — the marker `install` writes.
+/// The Copilot CLI hook events. Copilot accepts Claude Code's PascalCase event
+/// names as an explicit compatibility mode, which also switches its payloads to
+/// the snake_case field names the one hook client already reads, so the events
+/// line up — but the tool VOCABULARY is its own (`view` to read, `create` /
+/// `edit` / `str_replace_editor` / native `apply_patch` to write), and matchers
+/// test the runtime name. Reads fire here like they do on Claude Code, so the
+/// overlay rides post-read rather than the edit. `bash` is deliberately absent:
+/// Copilot has a native patch tool, so unlike Codex there is no heredoc route
+/// worth spawning this client for on every shell command.
+const SCRYER_COPILOT_HOOK_EVENTS: &[(&str, Option<&str>, u64)] = &[
+    ("SessionStart", None, 10),
+    ("PostToolUse", Some("view"), 10),
+    ("PostToolUse", Some("create|edit|str_replace_editor|apply_patch"), 10),
+    ("Stop", None, 15),
+];
+
+/// Does the command in this hook entry invoke scryer's hook client? The marker
+/// `install` writes, and the only thing that identifies an entry as ours.
+fn is_scryer_hook_command(command: &str) -> bool {
+    command.contains("scryer-mcp")
+        && command
+            .trim_end()
+            .trim_end_matches(" --copilot")
+            .ends_with(" hook")
+}
+
+/// Does this hook entry belong to scryer? Claude Code and Codex nest the
+/// commands under a `hooks` array; Copilot puts the command on the entry
+/// itself. Both shapes are checked so one predicate serves every install.
 fn is_scryer_hook_entry(entry: &serde_json::Value) -> bool {
+    if entry["command"]
+        .as_str()
+        .is_some_and(is_scryer_hook_command)
+    {
+        return true;
+    }
     entry["hooks"]
         .as_array()
         .into_iter()
         .flatten()
         .filter_map(|h| h["command"].as_str())
-        .any(|c| c.contains("scryer-mcp") && c.trim_end().ends_with(" hook"))
+        .any(is_scryer_hook_command)
 }
 
 /// Check if Claude Code has scryer's session hooks installed for the project.
@@ -147,6 +180,41 @@ fn check_codex_hooks(project_path: &str) -> bool {
     false
 }
 
+/// Where Copilot's hook registration goes. `.github/hooks/` is the only
+/// project-scoped location Copilot actually loads: the `hooks` key in
+/// `.github/copilot/settings.local.json` is documented but inert as of 1.0.61
+/// (verified against real sessions), and the user-level hooks directory is
+/// global to every project rather than an opt-in for this one.
+///
+/// It is a COMMITTED path, unlike Claude Code's `settings.local.json` — so this
+/// registration is shared with the checkout, the same way `.codex/hooks.json`
+/// already is. That costs teammates nothing: the registered command exits in
+/// milliseconds unless the Scryer app has this project open, so a checkout
+/// without Scryer — including a CI run of the Copilot cloud agent, which reads
+/// exactly this directory — sees no behaviour at all.
+///
+/// Scryer owns this file outright (hence its own name in a directory Copilot
+/// reads whole), which is what lets it be written wholesale rather than merged.
+fn copilot_hooks_path(project_path: &str) -> PathBuf {
+    PathBuf::from(project_path)
+        .join(".github")
+        .join("hooks")
+        .join("scryer.json")
+}
+
+/// Check if Copilot CLI has scryer's session hooks installed for the project.
+fn check_copilot_hooks(project_path: &str) -> bool {
+    if let Ok(contents) = std::fs::read_to_string(copilot_hooks_path(project_path)) {
+        if let Ok(root) = serde_json::from_str::<serde_json::Value>(&contents) {
+            return root
+                .pointer("/hooks/SessionStart")
+                .and_then(|v| v.as_array())
+                .is_some_and(|entries| entries.iter().any(is_scryer_hook_entry));
+        }
+    }
+    false
+}
+
 /// Check if a project has .codex/config.toml with a scryer MCP entry.
 fn check_codex_toml(project_path: &str) -> bool {
     let path = PathBuf::from(project_path).join(".codex").join("config.toml");
@@ -173,6 +241,7 @@ pub(crate) fn detect_ai_tools(project_path: Option<String>) -> serde_json::Value
     let claude_approved = project_path.as_deref().map(check_claude_approved).unwrap_or(false);
     let claude_hooks = project_path.as_deref().map(check_claude_hooks).unwrap_or(false);
     let codex_hooks = project_path.as_deref().map(check_codex_hooks).unwrap_or(false);
+    let copilot_hooks = project_path.as_deref().map(check_copilot_hooks).unwrap_or(false);
     let (claude_statusline, claude_statusline_foreign) =
         project_path.as_deref().map(check_claude_statusline).unwrap_or((false, false));
 
@@ -186,6 +255,7 @@ pub(crate) fn detect_ai_tools(project_path: Option<String>) -> serde_json::Value
         "claudeApproved": claude_approved,
         "claudeHooksEnabled": claude_hooks,
         "codexHooksEnabled": codex_hooks,
+        "copilotHooksEnabled": copilot_hooks,
         "claudeStatuslineEnabled": claude_statusline,
         "claudeStatuslineForeign": claude_statusline_foreign,
     })
@@ -308,6 +378,10 @@ pub(crate) fn setup_mcp_integration(
             let binary_path = find_scryer_mcp().ok_or("scryer-mcp binary not found")?;
             return write_codex_hooks(&project_path, &binary_path);
         }
+        "copilot_hooks" => {
+            let binary_path = find_scryer_mcp().ok_or("scryer-mcp binary not found")?;
+            return write_copilot_hooks(&project_path, &binary_path);
+        }
         "claude_statusline" => {
             let binary_path = find_scryer_mcp().ok_or("scryer-mcp binary not found")?;
             return write_claude_statusline(&project_path, &binary_path);
@@ -342,17 +416,7 @@ fn write_claude_statusline(project_path: &str, binary_path: &str) -> Result<Stri
     let claude_dir = PathBuf::from(project_path).join(".claude");
     let settings_path = claude_dir.join("settings.local.json");
 
-    let mut root: serde_json::Value = if settings_path.exists() {
-        let contents = std::fs::read_to_string(&settings_path).map_err(|e| e.to_string())?;
-        serde_json::from_str(&contents).map_err(|e| {
-            format!(
-                "{} is not valid JSON ({e}); refusing to overwrite it — fix the file and retry.",
-                settings_path.display()
-            )
-        })?
-    } else {
-        serde_json::json!({})
-    };
+    let mut root = read_json_or_refuse(&settings_path)?;
 
     if root
         .get("statusLine")
@@ -393,9 +457,75 @@ fn write_codex_hooks(project_path: &str, binary_path: &str) -> Result<String, St
     )
 }
 
-/// Idempotent hook install into one file's `{"hooks": {...}}` block — both
-/// harnesses use the same entry schema. Two passes because an event may get
-/// two scryer entries: first strip every prior scryer entry per event (they
+/// The same opt-in for Copilot CLI. Copilot reads every `*.json` in
+/// `.github/hooks/`, so scryer takes a file of its own and writes it whole —
+/// no merge pass, and nothing of anyone else's to preserve or corrupt, which is
+/// the one simplification this location buys over the shared settings files the
+/// other two installs have to edit in place. Re-installing is therefore
+/// idempotent by construction, and a previously corrupted file is repaired
+/// rather than refused (it is only ever scryer's own).
+///
+/// The entry schema is Copilot's: FLAT, with the command on the entry rather
+/// than nested under a `hooks` array. `timeout` is written rather than
+/// Copilot's own `timeoutSec` because it normalises one to the other, keeping a
+/// single vocabulary across the three installs. The registered command carries
+/// `--copilot` so the client knows whose tool names and reply shape to speak.
+fn write_copilot_hooks(project_path: &str, binary_path: &str) -> Result<String, String> {
+    let path = copilot_hooks_path(project_path);
+    let dir = path
+        .parent()
+        .ok_or("no parent directory for the Copilot hooks file")?
+        .to_path_buf();
+    let command = format!("\"{binary_path}\" hook --copilot");
+
+    let mut hooks = serde_json::Map::new();
+    for (event, matcher, timeout) in SCRYER_COPILOT_HOOK_EVENTS {
+        let mut entry = serde_json::json!({
+            "type": "command",
+            "command": command,
+            "timeout": timeout,
+        });
+        if let Some(m) = matcher {
+            entry["matcher"] = serde_json::json!(m);
+        }
+        hooks
+            .entry(event.to_string())
+            .or_insert_with(|| serde_json::json!([]))
+            .as_array_mut()
+            .unwrap()
+            .push(entry);
+    }
+    let root = serde_json::json!({ "version": 1, "hooks": hooks });
+
+    std::fs::create_dir_all(&dir).map_err(|e| e.to_string())?;
+    std::fs::write(
+        &path,
+        serde_json::to_string_pretty(&root).map_err(|e| e.to_string())?,
+    )
+    .map_err(|e| e.to_string())?;
+
+    Ok(path.to_string_lossy().to_string())
+}
+
+/// Read a settings file we're about to merge into. A file that doesn't parse is
+/// an ERROR, never a blank slate: a stray comma in the user's config must not
+/// cost them everything else the file holds.
+fn read_json_or_refuse(path: &Path) -> Result<serde_json::Value, String> {
+    if !path.exists() {
+        return Ok(serde_json::json!({}));
+    }
+    let contents = std::fs::read_to_string(path).map_err(|e| e.to_string())?;
+    serde_json::from_str(&contents).map_err(|e| {
+        format!(
+            "{} is not valid JSON ({e}); refusing to overwrite it — fix the file and retry.",
+            path.display()
+        )
+    })
+}
+
+/// Idempotent hook install into one file's `{"hooks": {...}}` block — Claude
+/// Code and Codex use the same entry schema. Two passes because an event may
+/// get two scryer entries: first strip every prior scryer entry per event (they
 /// all share the `… hook` command marker; foreign hooks are kept), then
 /// append the current set.
 fn write_scryer_hooks(
@@ -406,17 +536,7 @@ fn write_scryer_hooks(
 ) -> Result<String, String> {
     let command = format!("\"{}\" hook", binary_path);
 
-    let mut root: serde_json::Value = if file_path.exists() {
-        let contents = std::fs::read_to_string(file_path).map_err(|e| e.to_string())?;
-        serde_json::from_str(&contents).map_err(|e| {
-            format!(
-                "{} is not valid JSON ({e}); refusing to overwrite it — fix the file and retry.",
-                file_path.display()
-            )
-        })?
-    } else {
-        serde_json::json!({})
-    };
+    let mut root = read_json_or_refuse(file_path)?;
 
     if !root.get("hooks").is_some_and(|v| v.is_object()) {
         root["hooks"] = serde_json::json!({});
@@ -631,5 +751,88 @@ mod hook_install_tests {
         );
         assert_eq!(root["hooks"]["SessionStart"].as_array().unwrap().len(), 1);
         assert_eq!(root["hooks"]["Stop"].as_array().unwrap().len(), 1);
+    }
+
+    /// The Copilot install writes its own file in `.github/hooks/` using
+    /// Copilot's FLAT entry schema (command on the entry, not nested under a
+    /// `hooks` array), with Copilot's own tool names in the matchers and
+    /// `--copilot` on the command. Owning the file makes re-installing
+    /// idempotent by construction — and repairs a corrupted one, since there is
+    /// never anything of anyone else's in it to lose.
+    #[test]
+    fn copilot_hook_install_owns_its_file_and_is_idempotent() {
+        let dir = tempfile::tempdir().unwrap();
+        let hooks_file = dir.path().join(".github/hooks/scryer.json");
+        std::fs::create_dir_all(hooks_file.parent().unwrap()).unwrap();
+        std::fs::write(&hooks_file, "{ not json at all").unwrap();
+
+        let project = dir.path().to_string_lossy().to_string();
+        assert!(!check_copilot_hooks(&project));
+        write_copilot_hooks(&project, "/opt/scryer/scryer-mcp").unwrap();
+        write_copilot_hooks(&project, "/opt/scryer/scryer-mcp").unwrap();
+        assert!(check_copilot_hooks(&project));
+
+        let root: serde_json::Value =
+            serde_json::from_str(&std::fs::read_to_string(&hooks_file).unwrap()).unwrap();
+        assert_eq!(root["version"], 1);
+        let post = root["hooks"]["PostToolUse"].as_array().unwrap();
+        assert_eq!(post.len(), 2, "read overlay + write touch, no duplicates: {post:?}");
+        // Copilot's own tool vocabulary, matched on the runtime names.
+        assert!(post.iter().any(|e| e["matcher"] == "view"));
+        assert!(post
+            .iter()
+            .any(|e| e["matcher"] == "create|edit|str_replace_editor|apply_patch"));
+        // Flat schema, and the client is told which harness it is serving.
+        assert_eq!(post[0]["type"], "command");
+        assert_eq!(post[0]["command"], "\"/opt/scryer/scryer-mcp\" hook --copilot");
+        assert!(post.iter().all(is_scryer_hook_entry));
+        assert_eq!(root["hooks"]["SessionStart"].as_array().unwrap().len(), 1);
+        assert_eq!(root["hooks"]["Stop"].as_array().unwrap().len(), 1);
+    }
+
+    /// Sibling files in `.github/hooks/` belong to other tools — Copilot loads
+    /// the whole directory — so the install must never touch them.
+    #[test]
+    fn copilot_hook_install_leaves_sibling_hook_files_alone() {
+        let dir = tempfile::tempdir().unwrap();
+        let siblings = dir.path().join(".github/hooks/my-linter.json");
+        std::fs::create_dir_all(siblings.parent().unwrap()).unwrap();
+        let original = serde_json::json!({
+            "hooks": { "PostToolUse": [{ "type": "command", "command": "my-linter" }] }
+        })
+        .to_string();
+        std::fs::write(&siblings, &original).unwrap();
+
+        let project = dir.path().to_string_lossy().to_string();
+        write_copilot_hooks(&project, "/opt/scryer/scryer-mcp").unwrap();
+        assert_eq!(std::fs::read_to_string(&siblings).unwrap(), original);
+    }
+
+    /// A Copilot entry and a Claude/Codex entry are both recognised as ours —
+    /// one predicate over two schemas — while a foreign command in either shape
+    /// is left alone.
+    #[test]
+    fn scryer_entries_are_recognised_in_both_schemas() {
+        let nested = serde_json::json!({
+            "matcher": "Read",
+            "hooks": [{ "type": "command", "command": "\"/opt/scryer-mcp\" hook" }],
+        });
+        let flat = serde_json::json!({
+            "type": "command",
+            "matcher": "view",
+            "command": "\"/opt/scryer-mcp\" hook --copilot",
+        });
+        assert!(is_scryer_hook_entry(&nested));
+        assert!(is_scryer_hook_entry(&flat));
+
+        // Not ours: a foreign command, and a command that merely mentions the
+        // binary without being the hook client (e.g. a wrapper running
+        // `scryer-mcp check`).
+        assert!(!is_scryer_hook_entry(&serde_json::json!({
+            "type": "command", "command": "my-linter",
+        })));
+        assert!(!is_scryer_hook_entry(&serde_json::json!({
+            "type": "command", "command": "\"/opt/scryer-mcp\" check",
+        })));
     }
 }

--- a/src-tauri/src/preview.rs
+++ b/src-tauri/src/preview.rs
@@ -22,6 +22,10 @@ pub(crate) fn config_for_launch(
             kind: scryer_acp::AgentKind::Codex,
             ..
         } => (s.codex.model.clone(), s.codex.effort.clone()),
+        scryer_acp::AgentLaunch::Acp {
+            kind: scryer_acp::AcpKind::Copilot,
+            ..
+        } => (s.copilot.model.clone(), s.copilot.effort.clone()),
         _ => (String::new(), "medium".to_string()),
     }
 }
@@ -184,7 +188,7 @@ pub(crate) async fn start_preview_fixture_session(
 
     let settings = scryer_core::read_subagent_settings();
     let launch = scryer_acp::detect_available_agent_pref(&settings.agent)
-        .ok_or("No AI agent found. Install Claude Code or Codex first.")?;
+        .ok_or("No AI agent found. Install Claude Code, Codex or Copilot CLI first.")?;
 
     let parsed_ref = scryer_core::ModelRef::parse(&model_ref)?;
     let model = scryer_core::read_model_at(&parsed_ref)?;
@@ -235,8 +239,8 @@ pub(crate) async fn start_preview_fixture_session(
         scryer_acp::AgentLaunch::Cli { binary, kind } => {
             (binary, scryer_acp::runtime::LaunchMode::Cli { kind })
         }
-        scryer_acp::AgentLaunch::Acp { binary } => {
-            (binary, scryer_acp::runtime::LaunchMode::Acp)
+        scryer_acp::AgentLaunch::Acp { binary, kind } => {
+            (binary, scryer_acp::runtime::LaunchMode::Acp { kind })
         }
     };
 
@@ -275,7 +279,7 @@ pub(crate) async fn start_visual_variation_session(
 
     let settings = scryer_core::read_subagent_settings();
     let launch = scryer_acp::detect_available_agent_pref(&settings.agent)
-        .ok_or("No AI agent found. Install Claude Code or Codex first.")?;
+        .ok_or("No AI agent found. Install Claude Code, Codex or Copilot CLI first.")?;
 
     let parsed_ref = scryer_core::ModelRef::parse(&model_ref)?;
     let model = scryer_core::read_model_at(&parsed_ref)?;
@@ -336,8 +340,8 @@ pub(crate) async fn start_visual_variation_session(
         scryer_acp::AgentLaunch::Cli { binary, kind } => {
             (binary, scryer_acp::runtime::LaunchMode::Cli { kind })
         }
-        scryer_acp::AgentLaunch::Acp { binary } => {
-            (binary, scryer_acp::runtime::LaunchMode::Acp)
+        scryer_acp::AgentLaunch::Acp { binary, kind } => {
+            (binary, scryer_acp::runtime::LaunchMode::Acp { kind })
         }
     };
 

--- a/src/AgentLaunchConfirm.tsx
+++ b/src/AgentLaunchConfirm.tsx
@@ -122,7 +122,7 @@ export function AgentLaunchConfirm({
               </span>
             ) : (
               <span className="text-[var(--text-tertiary)]">
-                No agent detected — install Claude Code or Codex.
+                No agent detected — install Claude Code, Codex or Copilot CLI.
               </span>
             )}
           </div>

--- a/src/McpSetupPrompt.tsx
+++ b/src/McpSetupPrompt.tsx
@@ -14,7 +14,9 @@ import { BTN, BTN_GO } from "./pagekit";
  *  still missing — the consent list shown to the user. */
 function plannedWrites(tools: McpSetup["tools"]): string[] {
   const out: string[] = [];
-  if (tools.claude && !tools.claudeMcpEnabled) out.push(".mcp.json");
+  // Claude Code and Copilot share `.mcp.json`, so it's listed once for either.
+  if ((tools.claude && !tools.claudeMcpEnabled) || (tools.copilot && !tools.copilotMcpEnabled))
+    out.push(".mcp.json");
   if (tools.codex && !tools.codexMcpEnabled) out.push(".codex/config.toml");
   if (tools.claude && !tools.claudeApproved)
     out.push(".claude/settings.local.json — auto-approve all scryer tools");
@@ -34,8 +36,15 @@ export function McpSetupPrompt({
    *  and rely on the "Not now" button. Both routes call `setup.dismiss()`. */
   dismissable?: boolean;
 }) {
-  const { claude, codex } = setup.tools;
-  const agents = [claude && "Claude Code", codex && "Codex"].filter(Boolean).join(" and ");
+  const { claude, codex, copilot } = setup.tools;
+  const names = [claude && "Claude Code", codex && "Codex", copilot && "Copilot CLI"].filter(
+    Boolean,
+  ) as string[];
+  // "A", "A and B", "A, B and C" — three agents can be detected at once.
+  const agents =
+    names.length > 2
+      ? `${names.slice(0, -1).join(", ")} and ${names[names.length - 1]}`
+      : names.join(" and ");
   const writes = plannedWrites(setup.tools);
 
   const enable = async () => {
@@ -57,7 +66,7 @@ export function McpSetupPrompt({
       )}
       <div className="pr-4 text-xs font-medium text-[var(--text)]">Enable AI tool integration</div>
       <div className="text-2xs leading-relaxed text-[var(--text-muted)]">
-        {agents} {claude && codex ? "are" : "is"} installed. Wire scryer into this project so your
+        {agents} {names.length > 1 ? "are" : "is"} installed. Wire scryer into this project so your
         agent can read and update the model over MCP. This creates:
       </div>
       <ul className="flex flex-col gap-0.5 text-2xs text-[var(--text-secondary)]">

--- a/src/SettingsPanel.tsx
+++ b/src/SettingsPanel.tsx
@@ -6,7 +6,12 @@ import { Input, Select } from "./ui";
 import { BTN, BTN_GO, BTN_ICON, EYEBROW, SegField } from "./pagekit";
 import { useMcpSetup } from "./hooks/useMcpSetup";
 
-type AgentPref = "auto" | "claudeCode" | "codex";
+/** The agents a fill can run with, in the order they're fallen back to when the
+ *  preferred one isn't installed. Mirrors `detect_available_agent_pref`, so the
+ *  readout here and the agent that actually launches can't disagree. */
+const AGENTS = ["claudeCode", "codex", "copilot"] as const;
+type LaunchAgent = (typeof AGENTS)[number];
+type AgentPref = "auto" | LaunchAgent;
 
 interface AgentSettings {
   model: string;
@@ -17,6 +22,7 @@ export interface SubagentSettings {
   agent: AgentPref;
   claude: AgentSettings;
   codex: AgentSettings;
+  copilot: AgentSettings;
   /** Confirm before a UI action launches an agent. "Don't ask again" clears it. */
   confirmLaunch: boolean;
 }
@@ -24,13 +30,23 @@ export interface SubagentSettings {
 export interface Detected {
   claude: boolean;
   codex: boolean;
+  copilot: boolean;
 }
+
+/** Each agent's key in `Detected` and in the settings blocks — the same word in
+ *  both, so one map serves the availability check and the model/effort lookup. */
+const AGENT_KEY: Record<LaunchAgent, "claude" | "codex" | "copilot"> = {
+  claudeCode: "claude",
+  codex: "codex",
+  copilot: "copilot",
+};
 
 const DEFAULT_AGENT: AgentSettings = { model: "", effort: "medium" };
 export const SUBAGENT_DEFAULTS: SubagentSettings = {
   agent: "auto",
   claude: { ...DEFAULT_AGENT },
   codex: { ...DEFAULT_AGENT },
+  copilot: { ...DEFAULT_AGENT },
   confirmLaunch: true,
 };
 
@@ -39,44 +55,32 @@ export const SUBAGENT_DEFAULTS: SubagentSettings = {
  *  powerline so the launch readout and the editor can never disagree. `model`
  *  empty means the agent CLI's own default. */
 export interface ResolvedLaunch {
-  agent: "claudeCode" | "codex" | null;
+  agent: LaunchAgent | null;
   model: string;
   effort: string;
 }
 
-export const AGENT_LABEL: Record<"claudeCode" | "codex", string> = {
+export const AGENT_LABEL: Record<LaunchAgent, string> = {
   claudeCode: "Claude Code",
   codex: "Codex",
+  copilot: "Copilot CLI",
 };
 
 export function resolveLaunch(settings: SubagentSettings, detected: Detected): ResolvedLaunch {
-  const c = detected.claude;
-  const x = detected.codex;
-  const agent: ResolvedLaunch["agent"] =
-    settings.agent === "codex"
-      ? x
-        ? "codex"
-        : c
-          ? "claudeCode"
-          : null
-      : settings.agent === "claudeCode"
-        ? c
-          ? "claudeCode"
-          : x
-            ? "codex"
-            : null
-        : c
-          ? "claudeCode"
-          : x
-            ? "codex"
-            : null;
-  const a = agent === "codex" ? settings.codex : agent === "claudeCode" ? settings.claude : null;
+  const installed = (a: LaunchAgent) => detected[AGENT_KEY[a]];
+  // Preference first, then the standing order — so an uninstalled preference
+  // degrades to a working agent rather than to nothing.
+  const order: LaunchAgent[] =
+    settings.agent === "auto" ? [...AGENTS] : [settings.agent, ...AGENTS];
+  const agent = order.find(installed) ?? null;
+  const a = agent ? settings[AGENT_KEY[agent]] : null;
   return { agent, model: a?.model ?? "", effort: a?.effort ?? "" };
 }
 
 // Effort levels are agent-specific (from each CLI's own option set).
 const CLAUDE_EFFORT = ["low", "medium", "high", "xhigh", "max"];
 const CODEX_EFFORT = ["minimal", "low", "medium", "high", "xhigh"];
+const COPILOT_EFFORT = ["none", "low", "medium", "high", "xhigh", "max"];
 
 // Curated models. Claude aliases auto-track the latest version; Codex uses
 // explicit slugs. "Custom…" drops to a free-text field for anything else.
@@ -87,6 +91,18 @@ const CODEX_MODELS = [
   "gpt-5.4-mini",
   "gpt-5.3-codex",
   "gpt-5.3-codex-spark",
+];
+// Copilot fronts several providers on one subscription — the reason to want it
+// — so its shortlist spans them rather than favouring one. "auto" is Copilot's
+// own per-task pick, distinct from "Default" (whatever the CLI is set to).
+const COPILOT_MODELS = [
+  "auto",
+  "claude-opus-4.8",
+  "claude-sonnet-4.6",
+  "claude-haiku-4.5",
+  "gpt-5.5",
+  "gpt-5.3-codex",
+  "gemini-3.1-pro-preview",
 ];
 const CUSTOM = "__custom__";
 
@@ -101,7 +117,11 @@ export function SettingsPanel({
   projectPath?: string | null;
 }) {
   const [settings, setSettings] = useState<SubagentSettings>(SUBAGENT_DEFAULTS);
-  const [detected, setDetected] = useState<Detected>({ claude: false, codex: false });
+  const [detected, setDetected] = useState<Detected>({
+    claude: false,
+    codex: false,
+    copilot: false,
+  });
   const [saving, setSaving] = useState(false);
   const mcpSetup = useMcpSetup(projectPath ?? null);
 
@@ -110,7 +130,7 @@ export function SettingsPanel({
       .then((s) => setSettings({ ...SUBAGENT_DEFAULTS, ...s }))
       .catch(() => {});
     invoke<Detected>("detect_ai_tools", { projectPath: null })
-      .then((d) => setDetected({ claude: !!d.claude, codex: !!d.codex }))
+      .then((d) => setDetected({ claude: !!d.claude, codex: !!d.codex, copilot: !!d.copilot }))
       .catch(() => {});
   }, []);
 
@@ -158,9 +178,10 @@ export function SettingsPanel({
           </p>
 
           <Field label="Detected agents">
-            <div className="flex gap-4 text-xs">
-              <AgentStatus name="Claude Code" available={detected.claude} />
-              <AgentStatus name="Codex" available={detected.codex} />
+            <div className="flex flex-wrap gap-4 text-xs">
+              {AGENTS.map((a) => (
+                <AgentStatus key={a} name={AGENT_LABEL[a]} available={detected[AGENT_KEY[a]]} />
+              ))}
             </div>
           </Field>
 
@@ -168,16 +189,15 @@ export function SettingsPanel({
             <SegField<AgentPref>
               options={[
                 { value: "auto", label: "Auto" },
-                { value: "claudeCode", label: "Claude Code" },
-                { value: "codex", label: "Codex" },
+                ...AGENTS.map((a) => ({ value: a, label: AGENT_LABEL[a] })),
               ]}
               value={settings.agent}
               onChange={(agent) => setSettings((s) => ({ ...s, agent }))}
             />
             <p className="text-2xs text-[var(--text-muted)]">
               {resolvedAgent
-                ? `Fills will use ${resolvedAgent === "claudeCode" ? "Claude Code" : "Codex"}.`
-                : "No agent detected — install Claude Code or Codex."}
+                ? `Fills will use ${AGENT_LABEL[resolvedAgent]}.`
+                : "No agent detected — install Claude Code, Codex or Copilot CLI."}
             </p>
           </Field>
 
@@ -195,6 +215,14 @@ export function SettingsPanel({
             models={CODEX_MODELS}
             value={settings.codex}
             onChange={(codex) => setSettings((s) => ({ ...s, codex }))}
+          />
+
+          <AgentSettingsGroup
+            title="Copilot CLI"
+            efforts={COPILOT_EFFORT}
+            models={COPILOT_MODELS}
+            value={settings.copilot}
+            onChange={(copilot) => setSettings((s) => ({ ...s, copilot }))}
           />
 
           {projectPath &&

--- a/src/SettingsPanel.tsx
+++ b/src/SettingsPanel.tsx
@@ -197,7 +197,8 @@ export function SettingsPanel({
             onChange={(codex) => setSettings((s) => ({ ...s, codex }))}
           />
 
-          {projectPath && (mcpSetup.tools.claude || mcpSetup.tools.codex) && (
+          {projectPath &&
+            (mcpSetup.tools.claude || mcpSetup.tools.codex || mcpSetup.tools.copilot) && (
             <Field label="Session hooks (this project)">
               <p className="text-2xs leading-relaxed text-[var(--text-muted)]">
                 Let agent sessions see the model as they work: the status line on start, each
@@ -222,6 +223,22 @@ export function SettingsPanel({
                   busy={mcpSetup.busy}
                   onInstall={() => void mcpSetup.enableHooks("codex")}
                 />
+              )}
+              {mcpSetup.tools.copilot && (
+                <>
+                  <HooksRow
+                    name="Copilot CLI"
+                    target=".github/hooks/scryer.json"
+                    installed={mcpSetup.tools.copilotHooksEnabled}
+                    busy={mcpSetup.busy}
+                    onInstall={() => void mcpSetup.enableHooks("copilot")}
+                  />
+                  <p className="text-2xs leading-relaxed text-[var(--text-muted)]">
+                    Copilot loads a project's hooks — and its MCP servers — only in a folder
+                    you've trusted, and asks the first time you open one. Until you do, it stays
+                    silent about both.
+                  </p>
+                </>
               )}
             </Field>
           )}

--- a/src/SettingsPanel.tsx
+++ b/src/SettingsPanel.tsx
@@ -221,6 +221,7 @@ export function SettingsPanel({
             title="Copilot CLI"
             efforts={COPILOT_EFFORT}
             models={COPILOT_MODELS}
+            customNote="Copilot ignores a model name it doesn't recognise instead of reporting it, so a typo here runs on its default model rather than failing. Check the spelling against `copilot help config`."
             value={settings.copilot}
             onChange={(copilot) => setSettings((s) => ({ ...s, copilot }))}
           />
@@ -405,12 +406,16 @@ function AgentSettingsGroup({
   title,
   efforts,
   models,
+  customNote,
   value,
   onChange,
 }: {
   title: string;
   efforts: string[];
   models: string[];
+  /** Shown only when the free-text model field is open — for an agent whose CLI
+   *  won't tell the user when the name they typed doesn't land. */
+  customNote?: string;
   value: AgentSettings;
   onChange: (next: AgentSettings) => void;
 }) {
@@ -430,6 +435,7 @@ function AgentSettingsGroup({
         <Field label="Model">
           <ModelPicker
             aliases={models}
+            customNote={customNote}
             value={value.model}
             onChange={(model) => onChange({ ...value, model })}
           />
@@ -443,10 +449,12 @@ function AgentSettingsGroup({
  *  reveals a free-text field for full model names. */
 function ModelPicker({
   aliases,
+  customNote,
   value,
   onChange,
 }: {
   aliases: string[];
+  customNote?: string;
   value: string;
   onChange: (value: string) => void;
 }) {
@@ -477,12 +485,17 @@ function ModelPicker({
         }}
       />
       {custom && (
-        <Input
-          variant="bordered"
-          value={value}
-          placeholder="Full model name (e.g. claude-opus-4-7)"
-          onChange={(e) => onChange(e.target.value)}
-        />
+        <>
+          <Input
+            variant="bordered"
+            value={value}
+            placeholder="Full model name (e.g. claude-opus-4-7)"
+            onChange={(e) => onChange(e.target.value)}
+          />
+          {customNote && (
+            <p className="text-2xs leading-relaxed text-[var(--text-muted)]">{customNote}</p>
+          )}
+        </>
       )}
     </div>
   );

--- a/src/hooks/useLaunchSettings.ts
+++ b/src/hooks/useLaunchSettings.ts
@@ -26,14 +26,18 @@ export interface LaunchSettings {
 /// ever mounted.
 export function useLaunchSettings(): LaunchSettings {
   const [subagent, setSubagent] = useState<SubagentSettings>(SUBAGENT_DEFAULTS);
-  const [detected, setDetected] = useState<Detected>({ claude: false, codex: false });
+  const [detected, setDetected] = useState<Detected>({
+    claude: false,
+    codex: false,
+    copilot: false,
+  });
 
   const reload = useCallback(() => {
     invoke<SubagentSettings>("get_subagent_settings")
       .then((s) => setSubagent({ ...SUBAGENT_DEFAULTS, ...s }))
       .catch(() => {});
     invoke<Detected>("detect_ai_tools", { projectPath: null })
-      .then((d) => setDetected({ claude: !!d.claude, codex: !!d.codex }))
+      .then((d) => setDetected({ claude: !!d.claude, codex: !!d.codex, copilot: !!d.copilot }))
       .catch(() => {});
   }, []);
   useEffect(reload, [reload]);

--- a/src/hooks/useMcpSetup.ts
+++ b/src/hooks/useMcpSetup.ts
@@ -20,6 +20,10 @@ export interface AiToolsState {
   claudeHooksEnabled: boolean;
   /** Scryer's session hooks are registered in this project's `.codex/hooks.json`. */
   codexHooksEnabled: boolean;
+  /** Scryer's session hooks are registered in this project's
+   *  `.github/hooks/scryer.json` — the only project-scoped location Copilot
+   *  actually loads, and only once the folder is trusted. */
+  copilotHooksEnabled: boolean;
   /** Scryer's status one-liner is registered as this project's Claude Code
    *  statusLine — the persistent segment that also works while Scryer is closed. */
   claudeStatuslineEnabled: boolean;
@@ -38,6 +42,7 @@ const EMPTY: AiToolsState = {
   claudeApproved: false,
   claudeHooksEnabled: false,
   codexHooksEnabled: false,
+  copilotHooksEnabled: false,
   claudeStatuslineEnabled: false,
   claudeStatuslineForeign: false,
 };
@@ -56,11 +61,11 @@ export interface McpSetup {
    *  tool auto-approve in `.claude/settings.local.json` — then re-detect. */
   enable: () => Promise<void>;
   /** Explicit, separate opt-in: install scryer's session hooks for one tool —
-   *  Claude Code (`.claude/settings.local.json`) or Codex (`.codex/hooks.json`).
-   *  Never bundled into `enable` — the hooks change every session's behavior
-   *  (while the app is open), so they are only written when the user asks for
-   *  exactly that. */
-  enableHooks: (tool: "claude" | "codex") => Promise<void>;
+   *  Claude Code (`.claude/settings.local.json`), Codex (`.codex/hooks.json`)
+   *  or Copilot (`.github/hooks/scryer.json`). Never bundled into `enable` —
+   *  the hooks change every session's behavior (while the app is open), so they
+   *  are only written when the user asks for exactly that. */
+  enableHooks: (tool: "claude" | "codex" | "copilot") => Promise<void>;
   /** Its own opt-in, separate from the session hooks: register scryer's status
    *  one-liner as Claude Code's persistent statusLine. The only integration that
    *  keeps reporting while Scryer is closed (it reads the model off disk), so it
@@ -114,11 +119,11 @@ export function useMcpSetup(projectPath: string | null): McpSetup {
   }, [projectPath, tools, reload]);
 
   const enableHooks = useCallback(
-    async (tool: "claude" | "codex") => {
+    async (tool: "claude" | "codex" | "copilot") => {
       if (!projectPath) return;
       setBusy(true);
       try {
-        const action = tool === "codex" ? "codex_hooks" : "claude_hooks";
+        const action = `${tool}_hooks`;
         await invoke("setup_mcp_integration", { action, projectPath });
         reload();
       } finally {

--- a/src/hooks/useMcpSetup.ts
+++ b/src/hooks/useMcpSetup.ts
@@ -8,8 +8,13 @@ import { invoke } from "@tauri-apps/api/core";
 export interface AiToolsState {
   claude: boolean;
   codex: boolean;
+  copilot: boolean;
   claudeMcpEnabled: boolean;
   codexMcpEnabled: boolean;
+  /** Copilot reads the same `.mcp.json` Claude Code does (and an optional
+   *  committed `.github/mcp.json`), so this is usually true the moment
+   *  `claudeMcpEnabled` is — no config file of its own. */
+  copilotMcpEnabled: boolean;
   claudeApproved: boolean;
   /** Scryer's session hooks are registered in this project's Claude Code settings. */
   claudeHooksEnabled: boolean;
@@ -26,8 +31,10 @@ export interface AiToolsState {
 const EMPTY: AiToolsState = {
   claude: false,
   codex: false,
+  copilot: false,
   claudeMcpEnabled: false,
   codexMcpEnabled: false,
+  copilotMcpEnabled: false,
   claudeApproved: false,
   claudeHooksEnabled: false,
   codexHooksEnabled: false,
@@ -92,7 +99,9 @@ export function useMcpSetup(projectPath: string | null): McpSetup {
       // Only write what's actually missing, so re-enabling is a no-op rather
       // than churning files. Each command merges into existing config.
       const actions: string[] = [];
-      if (tools.claude && !tools.claudeMcpEnabled) actions.push("mcp");
+      // One `.mcp.json` write serves Claude Code and Copilot both.
+      if ((tools.claude && !tools.claudeMcpEnabled) || (tools.copilot && !tools.copilotMcpEnabled))
+        actions.push("mcp");
       if (tools.codex && !tools.codexMcpEnabled) actions.push("mcp_codex");
       if (tools.claude && !tools.claudeApproved) actions.push("claude_approve");
       for (const action of actions) {
@@ -136,7 +145,9 @@ export function useMcpSetup(projectPath: string | null): McpSetup {
   }, [projectPath]);
 
   const needsSetup =
-    (tools.claude && !tools.claudeMcpEnabled) || (tools.codex && !tools.codexMcpEnabled);
+    (tools.claude && !tools.claudeMcpEnabled) ||
+    (tools.codex && !tools.codexMcpEnabled) ||
+    (tools.copilot && !tools.copilotMcpEnabled);
   const dismissed = projectPath ? dismissedPaths.has(projectPath) : false;
 
   return { tools, needsSetup, dismissed, busy, enable, enableHooks, enableStatusline, dismiss, reload };


### PR DESCRIPTION
Closes #29.

Adds GitHub Copilot CLI as a third supported agent, across all three integration surfaces. Everything here was verified against real Copilot 1.0.61 sessions rather than from the docs — which matters, because the docs and the shipped behaviour disagree in two places.

## What landed

**MCP — nothing to build.** Copilot reads the same project `.mcp.json` Claude Code does, treats `"stdio"` as an alias of its own `"local"`, and defaults an entry with no `tools` key to every tool. The file scryer already writes serves it verbatim. The only gap was that nothing looked for `copilot` on PATH, so a Copilot-only project was told to go install Claude Code.

**Session hooks — one client, three harnesses.** Copilot accepts Claude Code's PascalCase event names as a compatibility mode, which switches its payloads to the snake_case fields the hook client already reads. Two things don't line up, and neither is visible in the event, so the install records which harness it is (`hook --copilot`) rather than leaving the client to sniff:

- Tool vocabulary: `view` / `create` / `edit` / `str_replace_editor` / `apply_patch`, the file in `path` not `file_path`, and a freeform patch as the whole `tool_input` string rather than a `.command` field.
- Injected context: a top-level `additionalContext` on SessionStart and PostToolUse, not the `hookSpecificOutput` envelope.

**Launch — ACP.** Copilot serves ACP from its own binary, so `AgentLaunch::Acp` now carries which dialect it is. Model and effort are server-level flags there, so they ride argv. The settings panel gains a Copilot block whose model list spans Claude, GPT and Gemini — the multi-provider point the issue was actually about.

## Two fixes here are not about Copilot

Both were latent, and Copilot only exposed them.

**The close gate never fired once per session.** Its reason text promises it does, but `/close` re-derived its answer from the touch log every time — the promise was kept entirely by Claude Code's `stop_hook_active` flag. Copilot sends no such flag. That's a hole on every harness, not a Copilot quirk: the gate exists to make an agent *look* at claims it touched, and "the claim still describes the code" is a legitimate verdict that writes nothing, so a re-derived gate would block the same session forever. Now enforced at the endpoint, aged out on the touch TTL.

**The ACP path had never worked.** `child` stayed in the frame that started the session and was spawned `kill_on_drop`, so the agent was killed the instant the session was handed back — every ACP session died between `session/new` and its first prompt. No ACP agent, adapter or otherwise, could ever have run. The child now lives in the session task, cancel kills the tree, and stderr is teed to the build logs: ACP has no channel for an agent's own diagnostics and stdout is the protocol, so a dead subprocess used to surface as nothing but `"server shut down unexpectedly"`.

## Where the docs are wrong

- **`.github/copilot/settings.local.json` does not load hooks.** It's documented; it's inert in 1.0.61, trusted or not. `.github/hooks/*.json` is the only project-scoped location that works, so scryer owns `.github/hooks/scryer.json` and writes it whole. It's committed rather than personal — that costs a checkout nothing, since the command exits in milliseconds unless the app has the project open, including in the Copilot cloud agent, which reads exactly this directory.
- **Copilot does not accept an MCP server over ACP.** Its `initialize` advertises `http` and `sse` transports and no stdio, and true to that it takes a stdio entry in `session/new` without complaint and then ignores it — the session simply has no scryer tools. It does read the project's `.mcp.json`, so that's the route in, and the launch now fails fast naming the file when it's missing rather than leaving a confused transcript to interpret.

## Caveats worth knowing

- **Folder trust gates everything Copilot** — project MCP servers *and* hooks. Untrusted, it stays silent about both, and there's no way to detect that from scryer, so it's surfaced as text in the settings panel and README. If someone reports "Copilot doesn't see scryer", that's the first question to ask.
- **An unrecognised model is ignored in ACP mode**, not rejected as it is under `-p`, so a typo in the custom-model field runs on Copilot's default. The field says so.
- `.github/hooks/scryer.json` carries an absolute path to the installer's `scryer-mcp`, so it's machine-specific in a committed file. Harmless — inert without the app — and `.codex/hooks.json` already behaves this way, but it now shows up in diffs. The root cause is that `scryer-mcp` ships beside the app rather than on PATH; worth a follow-up.

## Verification

Against real Copilot 1.0.61 sessions:

- Hooks: SessionStart reached `/status`, a `view` injected the file's claims (the agent echoed a directive planted only in the overlay), an edit recorded a touch, and the close gate blocked once, got a reconciliation, then let the session finish.
- ACP: `get_health` called from inside a Copilot ACP session, returning this project's real model status — with the default model, and again with an explicit `claude-haiku-4.5` / `low`.
- The missing-`.mcp.json` guard and the folder-trust gate were each confirmed by removing them and watching the setup go silent.

Adds an `acp_smoke` example that runs the ACP check, since that path had no way to be exercised before. Workspace tests and `tsc` clean; no new clippy warnings.