### PR TITLE
Give directives one deliberate write path, used only on explicit request

### DIFF
--- a/crates/scryer-core/src/model.rs
+++ b/crates/scryer-core/src/model.rs
@@ -64,9 +64,11 @@ pub struct Responsibility {
     #[serde(default, skip_serializing_if = "Option::is_none")]
     pub stale_proposal: Option<String>,
     /// Optional prescriptive HOW-constraints — verb-led "must"/"never" rules
-    /// the implementation has to satisfy. User-authored: read-only to the agent,
-    /// so hidden from write-tool input schemas (`schemars(skip)`) while still
-    /// serialized for storage and surfaced on read. Not part of conformance.
+    /// the implementation has to satisfy. User-authored: read-only to the
+    /// agent's ordinary writes, so hidden from write-tool input schemas
+    /// (`schemars(skip)`) while still serialized for storage and surfaced on
+    /// read; `set_directives` is the one deliberate write path, reserved for
+    /// edits the user explicitly requested. Not part of conformance.
     #[serde(default, skip_serializing_if = "Vec::is_empty")]
     #[schemars(skip)]
     pub directives: Vec<String>,
@@ -268,10 +270,11 @@ pub struct Node {
     /// responsibility's `directives`. These CARRY DOWN: a node is bound by its
     /// own directives plus every ancestor's, computed at read time (never copied
     /// onto descendants), so editing a container's directive instantly re-binds
-    /// its whole subtree. User-authored: read-only to the agent, so hidden from
-    /// write-tool input schemas (`schemars(skip)`) while still serialized for
-    /// storage and surfaced (own + inherited) on read. Plain text — not part of
-    /// conformance.
+    /// its whole subtree. User-authored: read-only to the agent's ordinary
+    /// writes, so hidden from write-tool input schemas (`schemars(skip)`) while
+    /// still serialized for storage and surfaced (own + inherited) on read;
+    /// `set_directives` is the one deliberate write path, reserved for edits
+    /// the user explicitly requested. Plain text — not part of conformance.
     #[serde(default, skip_serializing_if = "Vec::is_empty")]
     #[schemars(skip)]
     pub directives: Vec<String>,

--- a/crates/scryer-core/src/rules.rs
+++ b/crates/scryer-core/src/rules.rs
@@ -20,7 +20,7 @@ pub const RULES: &[Rule] = &[
         id: 1,
         title: "Responsibilities are pure business statements",
         tags: &["responsibility", "business", "mechanism", "directives", "wording"],
-        body: r#"A responsibility says what a node is accountable for in business terms — not how it does it. "restricts access to private content" — yes. "restricts access via JWT" — no, the "via JWT" is mechanism. Same for technology names, library calls, specific protocols. Keep mechanism out of the statement entirely. The `directives` field beside a responsibility holds prescriptive "must"/"never" constraints ("must verify ownership server-side", "never trust a client-supplied role") — but directives are authored by the user, not the agent. Treat any directives present as binding constraints you must satisfy when implementing; never write, edit, or delete them. Where reality discharges a responsibility belongs in the source map, not in directives."#,
+        body: r#"A responsibility says what a node is accountable for in business terms — not how it does it. "restricts access to private content" — yes. "restricts access via JWT" — no, the "via JWT" is mechanism. Same for technology names, library calls, specific protocols. Keep mechanism out of the statement entirely. The `directives` field beside a responsibility holds prescriptive "must"/"never" constraints ("must verify ownership server-side", "never trust a client-supplied role") — but directives are authored by the user, not the agent. Treat any directives present as binding constraints you must satisfy when implementing; write, edit, or delete them only when the user explicitly asks for it. Where reality discharges a responsibility belongs in the source map, not in directives."#,
     },
     Rule {
         id: 2,
@@ -93,7 +93,7 @@ NEVER describe a data shape in a responsibility statement. "Defines the lead rec
         id: 12,
         title: "`technology` is node identity",
         tags: &["technology", "identity", "directives"],
-        body: r#"`technology` is what the node IS as software ("Payload 3.0", "PostgreSQL 16", "S3 Bucket"). Separate from `directives` on responsibilities, which are user-authored constraints prescribing how a responsibility must be discharged — never set by the agent. Do not put technology vocabulary inside responsibility statements."#,
+        body: r#"`technology` is what the node IS as software ("Payload 3.0", "PostgreSQL 16", "S3 Bucket"). Separate from `directives` on responsibilities, which are user-authored constraints prescribing how a responsibility must be discharged — set by the agent only at the user's explicit request. Do not put technology vocabulary inside responsibility statements."#,
     },
     Rule {
         id: 14,

--- a/crates/scryer-mcp/src/helpers.rs
+++ b/crates/scryer-mcp/src/helpers.rs
@@ -157,16 +157,18 @@ pub(crate) fn breadcrumb(model: &ScryModel, node_id: &str) -> String {
     names.join(" / ")
 }
 
-/// Directives are user-authored and read-only to the AI — both a
-/// responsibility's `directives` and a node's own node-level `directives`.
-/// Before committing any AI write, force each back to whatever the prior
-/// on-disk model held for that id; ids with no prior entry get none. This lets
-/// the AI create, edit, and move responsibilities and nodes while leaving
-/// directives entirely under the user's control. (The interactive patch path
-/// can't reach them — they're `schemars(skip)` — but the whole-node generation
-/// primitives `set_model`/`set_node` rebuild nodes from JSON and would
-/// otherwise drop them.) Not applied to `move_responsibilities`, which
-/// preserves directives across a deliberate responsibility-id rename.
+/// Directives are user-authored and read-only to the AI's ordinary writes —
+/// both a responsibility's `directives` and a node's own node-level
+/// `directives`. Before committing any AI write, force each back to whatever
+/// the prior on-disk model held for that id; ids with no prior entry get none.
+/// This lets the AI create, edit, and move responsibilities and nodes while
+/// leaving directives entirely under the user's control. (The interactive
+/// patch path can't reach them — they're `schemars(skip)` — but the whole-node
+/// generation primitives `set_model`/`set_node` rebuild nodes from JSON and
+/// would otherwise drop them.) Not applied to `move_responsibilities`, which
+/// preserves directives across a deliberate responsibility-id rename — nor to
+/// `set_directives`, the one deliberate write path, reserved for edits the
+/// user explicitly asked for.
 pub(crate) fn enforce_readonly_directives(model: &mut ScryModel, prior: &ScryModel) {
     let prior_resps = prior
         .nodes

--- a/crates/scryer-mcp/src/instructions.rs
+++ b/crates/scryer-mcp/src/instructions.rs
@@ -26,7 +26,8 @@ to see where work is needed, then `search_model` / `read_model` to load the \
 governing nodes, their responsibilities, and any binding `directives`. Directives are user-authored, \
 read-only HOW-constraints (\"must\"/\"never\" rules). They attach to a responsibility OR to a node, and \
 node-level directives CARRY DOWN: a node is bound by its own plus every ancestor's. `read_model` \
-returns the inherited set in `inheritedDirectives`; honor all of them and never edit a directive.\n\
+returns the inherited set in `inheritedDirectives`; honor all of them, and never edit a directive \
+unless the user explicitly asks you to.\n\
 2. PLAN — author the intended change into the model BEFORE writing code: add/extend the nodes, \
 responsibilities, and links it implies, at the right altitude, with the intent tools (`add_person` / \
 `add_system` / `add_container` / `add_component` / `add_symbol`, `update_nodes`, `add_links`, …). \

--- a/crates/scryer-mcp/src/tools/nodes.rs
+++ b/crates/scryer-mcp/src/tools/nodes.rs
@@ -795,6 +795,81 @@ impl ScryerServer {
     }
 
     #[tool(
+        description = "Replace the directives on nodes or responsibilities — the ONE write path to directives, which every other tool leaves read-only. Directives are the USER's prescriptive HOW-constraints: call this ONLY when the user has explicitly asked, in this conversation, for directives to be written, edited, or deleted (e.g. a bulk reword they dictated) — never on your own initiative, and never to relax a constraint you find inconvenient while implementing. Each item names a `node_id` (node-level directives, binding that node's whole subtree) OR a `responsibility_id` (that claim's directives), plus `directives` as the FULL replacement array — an empty array clears. Writes the plan layer like other authoring tools; the change surfaces in the plan diff for the user to see."
+    )]
+    fn set_directives(
+        &self,
+        Parameters(req): Parameters<SetDirectivesRequest>,
+    ) -> Result<CallToolResult, McpError> {
+        let model_ref = resolve_model_ref(req.project.as_deref())?;
+        let _lock = match lock_or_err(&model_ref) {
+            Ok(l) => l,
+            Err(e) => return Ok(e),
+        };
+        let mut model = match scryer_core::read_planned_seeded_at(&model_ref) {
+            Ok(m) => m,
+            Err(e) => {
+                return Ok(CallToolResult::error(vec![Content::text(read_fail("model", &model_ref, &e))]));
+            }
+        };
+
+        let mut updated = 0usize;
+        for item in &req.items {
+            match (&item.node_id, &item.responsibility_id) {
+                (Some(node_id), None) => {
+                    let Some(n) = model.nodes.iter_mut().find(|n| &n.id == node_id) else {
+                        return Ok(CallToolResult::error(vec![Content::text(format!(
+                            "Node '{}' not found",
+                            node_id
+                        ))]));
+                    };
+                    n.directives = item.directives.clone();
+                }
+                (None, Some(resp_id)) => {
+                    let resp = model
+                        .nodes
+                        .iter_mut()
+                        .flat_map(|n| n.responsibilities.iter_mut())
+                        .chain(model.groups.iter_mut().flat_map(|g| g.responsibilities.iter_mut()))
+                        .find(|r| &r.id == resp_id);
+                    let Some(r) = resp else {
+                        return Ok(CallToolResult::error(vec![Content::text(format!(
+                            "Responsibility '{}' not found",
+                            resp_id
+                        ))]));
+                    };
+                    r.directives = item.directives.clone();
+                }
+                _ => {
+                    return Ok(CallToolResult::error(vec![Content::text(
+                        "Each item must set exactly one of `node_id` or `responsibility_id`"
+                            .to_string(),
+                    )]));
+                }
+            }
+            updated += 1;
+        }
+
+        let tag_warnings = match write_planned_tagged(
+            &model_ref,
+            &mut model,
+            self.session_change(&model_ref).as_deref(),
+        ) {
+            Ok(w) => w,
+            Err(e) => return Ok(CallToolResult::error(vec![Content::text(e)])),
+        };
+        drop(_lock);
+        let mut msg = format!("Set directives on {} target(s)", updated);
+        for w in &tag_warnings {
+            msg.push_str(&format!("\n{w}"));
+        }
+        if let Some(h) = status_header(&model_ref) {
+            msg.push_str(&format!("\n{h}"));
+        }
+        Ok(CallToolResult::success(vec![Content::text(msg)]))
+    }
+
+    #[tool(
         description = "Fold a node's outstanding planned work into the committed model after you've written the code — the counterpart to `get_pending`, which closes the loop. This is THE build checkpoint, and it is one atomic statement with three parts: the fold ('I built this'), `anchors` ('here is where it lives'), and `tests` ('here is the test I attached to it') — pass all three in the SAME call rather than folding now and anchoring/attaching later. Folding overwrites the committed claim with the clean planned copy, clearing the `stale` drift flag on anything it folds (re-implementation is the verdict that resolves it). With no `responsibilityIds`, folds every planned responsibility and property on the node, plus the appearance (the visual) — EXCEPT vagrant (code-discovered) claims and properties, which are left in the plan awaiting an explicit adopt/reject verdict and never bypass into the committed model. Pass `responsibilityIds` to fold only those responsibilities, and/or `propertyLabels` to fold only those data fields (properties are identified by label). A whole-node fold also pulls in the plan links touching this node once BOTH their endpoints are committed, and any group this node completes (every member committed). Standalone link/group changes — and EVERY link/group DELETION, which never rides a node fold — fold by their own ids instead: pass `link_ids` / `group_ids`, with or without a `node_id`. In a DESIGN-FIRST model (never committed), folding a built leaf is refused while its ancestors are plan-only — pass `commit_ancestors: true` to fold the ancestor chain structure-only first: the ancestors' identity and boundaries land in committed while their unbuilt claims stay pending in the plan, so partial implementation reads honestly. Call this when you finish implementing, so the plan clears and the model stops reporting the work as outstanding. Pass `anchors` (same shape as update_source_map `entries`) to anchor the folded claims to code IN THE SAME CALL — 'here's what I built and where it lives' as one atomic statement; an unanchored claim reads as scaffolding and carries no drift tripwire. Pass `tests` (same shape) to ATTACH each claim's test alongside — 'and this test exercises it' (`pattern` = test file, `symbol` = the test function; optional `command` records how to run it, never executed). For a claim in a When/While/If form the test is EXPECTED, not opportunistic — and on a symbol host it is MANDATORY (rule 22): the claim names a concrete trigger/state/failure, so write the test that arranges it and asserts the response, and attach it here in the same call. A fold that leaves a testable claim with no test attached succeeds, but the response calls out each such claim and how to fix it; health counts them as `untested`. Ubiquitous claims stay a judgment call; absence is simply visible in health. Every node fold's response ends with a scoped POST-FLIGHT: what's still pending on that node, which of its committed claims lack anchors, and any validation warnings this fold introduced — act on those lines; you do not need a separate validate_model run after every fold. If you DELETED a node in the plan (intending the code to go away) and have now removed that code, call this with the node id to fold the deletion into the committed model. Pass `change` (standalone — a change id from `set_change`/`get_pending`) to fold an ENTIRE change: every plan entry tagged to it, in dependency order; when its last entry folds, the change closes and its rationale is recorded in the history log. NOTE: this is for code you actually changed — to drop something from the model WITHOUT touching code, use `descope` instead."
     )]
     fn mark_implemented(
@@ -2128,6 +2203,168 @@ mod tests {
             scryer_core::working_view(&committed, &planned).source_map.contains_key("r-main"),
             "the working view still lights the file"
         );
+    }
+
+    /// set_directives is the ONE deliberate write path to directives (every
+    /// other tool restores them via enforce_readonly_directives). It replaces
+    /// the full array on a node (node-level), a node-hosted claim, and a
+    /// group-hosted claim — writing the PLAN layer only, like the other
+    /// authoring tools, so the edit surfaces in the plan diff.
+    #[test]
+    fn set_directives_replaces_on_node_and_responsibility_hosts() {
+        let dir = tempfile::tempdir().unwrap();
+        let model_ref = ModelRef::ProjectLocal(dir.path().to_path_buf());
+
+        let mut m = ScryModel::new();
+        let mut sys = node("sys", Kind::System, "S", None);
+        sys.directives = vec!["old node rule".into()];
+        let mut con = node("con", Kind::Container, "C", Some("sys"));
+        con.responsibilities = vec![resp("r-con")];
+        m.nodes.push(sys);
+        m.nodes.push(con);
+        m.groups.push(scryer_core::Group {
+            id: "grp".into(),
+            name: "G".into(),
+            description: None,
+            member_ids: Vec::new(),
+            parent_group_id: None,
+            parent_node_id: Some("sys".into()),
+            responsibilities: vec![resp("r-grp")],
+            icon: None,
+        });
+        scryer_core::write_model_at(&model_ref, &m).unwrap();
+        scryer_core::write_planned_at(&model_ref, &m).unwrap();
+
+        let server = ScryerServer::new();
+        let item = |n: Option<&str>, r: Option<&str>, d: &[&str]| SetDirectivesItem {
+            node_id: n.map(Into::into),
+            responsibility_id: r.map(Into::into),
+            directives: d.iter().map(|s| s.to_string()).collect(),
+        };
+        let res = server
+            .set_directives(Parameters(SetDirectivesRequest {
+                project: Some(dir.path().to_string_lossy().to_string()),
+                items: vec![
+                    item(Some("sys"), None, &["must stay stateless"]),
+                    item(None, Some("r-con"), &["never trust client input"]),
+                    item(None, Some("r-grp"), &["must audit-log"]),
+                ],
+            }))
+            .unwrap();
+        assert_ne!(res.is_error, Some(true), "{:?}", res.content);
+
+        let planned = scryer_core::read_planned_at(&model_ref).unwrap();
+        let sys = planned.nodes.iter().find(|n| n.id == "sys").unwrap();
+        assert_eq!(sys.directives, vec!["must stay stateless"], "node-level replaced");
+        let con = planned.nodes.iter().find(|n| n.id == "con").unwrap();
+        assert_eq!(con.responsibilities[0].directives, vec!["never trust client input"]);
+        assert_eq!(planned.groups[0].responsibilities[0].directives, vec!["must audit-log"]);
+
+        // The committed model is untouched — the edit is plan work like any
+        // other authoring write, visible in the plan diff until folded.
+        let committed = scryer_core::read_model_at(&model_ref).unwrap();
+        let sys_c = committed.nodes.iter().find(|n| n.id == "sys").unwrap();
+        assert_eq!(sys_c.directives, vec!["old node rule"], "committed layer untouched");
+    }
+
+    /// An empty replacement array CLEARS — without it directives could be set
+    /// but never removed through this tool.
+    #[test]
+    fn set_directives_clears_with_an_empty_array() {
+        let dir = tempfile::tempdir().unwrap();
+        let model_ref = ModelRef::ProjectLocal(dir.path().to_path_buf());
+
+        let mut m = ScryModel::new();
+        let mut sys = node("sys", Kind::System, "S", None);
+        let mut r = resp("r-sys");
+        r.directives = vec!["must do things".into()];
+        sys.responsibilities = vec![r];
+        sys.directives = vec!["a node rule".into()];
+        m.nodes.push(sys);
+        scryer_core::write_model_at(&model_ref, &m).unwrap();
+        scryer_core::write_planned_at(&model_ref, &m).unwrap();
+
+        let server = ScryerServer::new();
+        server
+            .set_directives(Parameters(SetDirectivesRequest {
+                project: Some(dir.path().to_string_lossy().to_string()),
+                items: vec![
+                    SetDirectivesItem {
+                        node_id: Some("sys".into()),
+                        responsibility_id: None,
+                        directives: Vec::new(),
+                    },
+                    SetDirectivesItem {
+                        node_id: None,
+                        responsibility_id: Some("r-sys".into()),
+                        directives: Vec::new(),
+                    },
+                ],
+            }))
+            .unwrap();
+
+        let planned = scryer_core::read_planned_at(&model_ref).unwrap();
+        let sys = planned.nodes.iter().find(|n| n.id == "sys").unwrap();
+        assert!(sys.directives.is_empty(), "node-level cleared");
+        assert!(sys.responsibilities[0].directives.is_empty(), "claim-level cleared");
+    }
+
+    /// An unknown id — or an item that names both / neither target — is
+    /// rejected before anything lands, leaving the model untouched.
+    #[test]
+    fn set_directives_rejects_bad_items_without_writing() {
+        let dir = tempfile::tempdir().unwrap();
+        let model_ref = ModelRef::ProjectLocal(dir.path().to_path_buf());
+
+        let mut m = ScryModel::new();
+        let mut sys = node("sys", Kind::System, "S", None);
+        sys.directives = vec!["keep me".into()];
+        m.nodes.push(sys);
+        scryer_core::write_model_at(&model_ref, &m).unwrap();
+        scryer_core::write_planned_at(&model_ref, &m).unwrap();
+
+        let server = ScryerServer::new();
+        let bad_items = [
+            SetDirectivesItem {
+                node_id: Some("nope".into()),
+                responsibility_id: None,
+                directives: vec!["x".into()],
+            },
+            SetDirectivesItem {
+                node_id: None,
+                responsibility_id: Some("nope".into()),
+                directives: vec!["x".into()],
+            },
+            SetDirectivesItem {
+                node_id: Some("sys".into()),
+                responsibility_id: Some("r-x".into()),
+                directives: vec!["x".into()],
+            },
+            SetDirectivesItem { node_id: None, responsibility_id: None, directives: vec!["x".into()] },
+        ];
+        for bad in bad_items {
+            // A valid edit batched BEHIND the bad item must not land either.
+            let res = server
+                .set_directives(Parameters(SetDirectivesRequest {
+                    project: Some(dir.path().to_string_lossy().to_string()),
+                    items: vec![
+                        bad,
+                        SetDirectivesItem {
+                            node_id: Some("sys".into()),
+                            responsibility_id: None,
+                            directives: vec!["should not land".into()],
+                        },
+                    ],
+                }))
+                .unwrap();
+            assert_eq!(res.is_error, Some(true));
+            let planned = scryer_core::read_planned_at(&model_ref).unwrap();
+            assert_eq!(
+                planned.nodes[0].directives,
+                vec!["keep me"],
+                "model untouched after a rejected batch"
+            );
+        }
     }
 
     /// Canvas placements are user-authored, like directives: a whole-model

--- a/crates/scryer-mcp/src/types.rs
+++ b/crates/scryer-mcp/src/types.rs
@@ -361,6 +361,26 @@ pub(crate) struct UpdateNodeRequest {
 }
 
 #[derive(Debug, Deserialize, schemars::JsonSchema)]
+pub(crate) struct SetDirectivesItem {
+    /// Node id — replaces that node's own node-level directives (which carry down,
+    /// binding its whole subtree). Exactly one of `node_id` / `responsibility_id` per item.
+    pub node_id: Option<String>,
+    /// Responsibility id — replaces that claim's directives. The claim may live on a
+    /// node or on a group. Exactly one of `node_id` / `responsibility_id` per item.
+    pub responsibility_id: Option<String>,
+    /// Full replacement list of directives — verb-led "must"/"never" constraints.
+    /// Pass an empty array to clear.
+    pub directives: Vec<String>,
+}
+
+#[derive(Debug, Deserialize, schemars::JsonSchema)]
+pub(crate) struct SetDirectivesRequest {
+    pub project: Option<String>,
+    /// Directive replacements to apply. Batch-friendly: one item per node or responsibility.
+    pub items: Vec<SetDirectivesItem>,
+}
+
+#[derive(Debug, Deserialize, schemars::JsonSchema)]
 pub(crate) struct SetNodeRequest {
     pub project: Option<String>,
     /// ID of the existing node whose subtree is being replaced.


### PR DESCRIPTION
Closes #31.

## What

Adds a `set_directives` MCP tool — the one deliberate write path to directives, which every other tool continues to treat as read-only.

- Batch-friendly (the issue's use-case is bulk rewording): each item names a `node_id` (node-level directives, binding the subtree) **or** a `responsibility_id` (node- or group-hosted claim), plus the full replacement `directives` array; an empty array clears.
- Writes the **plan layer** via the same tagged-write path as `update_nodes` — mirroring the canvas, which also writes planned on a user directive edit — so the change surfaces in the plan diff as a "reworded directives" entry and folds through the normal flow. `last_touched_at` stamping comes free from the core write path.
- Any bad item (unknown id, both/neither ids set) rejects the whole batch before anything is written.

## The guardrail

The agent is told to use it **only when the user explicitly asks** for directive edits in the conversation — never on its own initiative, and never to relax a constraint it finds inconvenient while implementing. That line is drawn in the tool's own description, the server instructions, and rules 1 and 12; no other surface (orient, health, ACP prompt) advertises the capability.

The existing protections are untouched: `directives` stays `schemars(skip)` in every other write schema, and `enforce_readonly_directives` still restores directives across all raw whole-node writes.

## Tests

Three new unit tests: replacement across all three host shapes (with the committed layer verified untouched), clear-with-empty-array, and rejection-without-writing for every bad-item shape. Full workspace suite passes (367 tests).

🤖 Generated with [Claude Code](https://claude.com/claude-code)