### PR TITLE
Fix/commit seam id uniqueness gate

### DIFF
--- a/crates/scryer-core/src/storage.rs
+++ b/crates/scryer-core/src/storage.rs
@@ -103,6 +103,22 @@ pub fn write_model_at(r: &ModelRef, model: &ScryModel) -> Result<(), String> {
     // caller — a plan-derived model (fold, set_model) rides through this path.
     stamped.changes.clear();
     stamped.change_map.clear();
+    // Structural-invariant gate. This is the single committed-layer writer every
+    // commit / fold / set_model rides through, so refusing here is what keeps a
+    // silently-misbindable duplicate — most notably the same responsibility id
+    // on two hosts, left behind when a move added the claim to its new host but
+    // never removed the old copy — out of `model.scry`. Such a duplicate is
+    // invisible to the plan diff (its id-keyed index keeps only one copy), so
+    // once written the stale copy sits wrong indefinitely with nothing able to
+    // surface it. Fail loud at the seam instead, naming every violation.
+    let violations = crate::validate::structural_violations(&stamped);
+    if !violations.is_empty() {
+        return Err(format!(
+            "refusing to write committed model — structural invariant violation(s) that the \
+             plan diff cannot see and would leave wrong indefinitely:\n  - {}",
+            violations.join("\n  - ")
+        ));
+    }
     let json = serde_json::to_string_pretty(&stamped).map_err(|e| e.to_string())?;
     write_model_raw_at(r, &json)
 }
@@ -609,6 +625,35 @@ mod tests {
         assert!(!r.sync_path().exists(), "reconcile anchor removed");
         assert!(r.lock_path().exists(), "infra lock file is kept");
         drop(guard);
+    }
+
+    /// The committed-write seam refuses a model carrying a silently-misbindable
+    /// duplicate — here the same responsibility id on two hosts, the exact state
+    /// a botched move leaves behind (added to the new host, never removed from
+    /// the old). Persisting it would hide the stale copy from the plan diff
+    /// indefinitely, so the write must fail, name the violation, and touch
+    /// nothing on disk.
+    #[test]
+    fn write_model_rejects_a_cross_host_duplicate_responsibility() {
+        let (_dir, r) = temp_ref();
+        let mut m = one_resp_model("do the thing"); // node n1 carries resp r1
+        let mut n2 = one_resp_model("do the thing").nodes.remove(0);
+        n2.id = "n2".into(); // second host reusing responsibility id r1
+        m.nodes.push(n2);
+
+        let err = write_model_at(&r, &m).expect_err("duplicate resp id must be refused");
+        assert!(err.contains("globally unique"), "names the invariant: {err}");
+        assert!(err.contains("r1"), "names the colliding id: {err}");
+        assert!(!r.model_path().exists(), "nothing was persisted");
+    }
+
+    /// A structurally sound model still writes cleanly — the gate is invisible to
+    /// ordinary writes.
+    #[test]
+    fn write_model_accepts_a_clean_model() {
+        let (_dir, r) = temp_ref();
+        write_model_at(&r, &one_resp_model("do the thing")).expect("valid model writes");
+        assert!(r.model_path().exists());
     }
 
     /// A tag-only change never folds (`diff` ignores `concern`), so writing the

--- a/crates/scryer-core/src/validate.rs
+++ b/crates/scryer-core/src/validate.rs
@@ -364,6 +364,103 @@ pub fn validate(model: &ScryModel) -> Vec<String> {
     warnings
 }
 
+/// The subset of model problems that are *structural invariant violations*: an
+/// id that downstream code treats as unique actually names two things, so an
+/// id-keyed lookup silently binds to whichever host the model lists first
+/// (`find_responsibility`, `commit.rs`) and the plan diff's id-keyed index
+/// (`diff::index_responsibilities` / `indexResponsibilities`) keeps only one
+/// copy per id, dropping the other without a trace.
+///
+/// Unlike the advisory findings [`validate`] also returns (length caps,
+/// disconnected nodes, link legality — all legitimate transient states), these
+/// are never a valid *committed* state. A duplicate that reaches `model.scry` is
+/// invisible to the plan diff: `from` and `to` both collapse to a single copy,
+/// they compare equal, no change is emitted, and the stale wrong copy sits
+/// committed indefinitely. [`crate::write_model_at`] gates every committed write
+/// on this returning empty, so the committed layer can never hold one.
+///
+/// Returns stable, de-duplicated messages (empty ⇒ no violation).
+pub fn structural_violations(model: &ScryModel) -> Vec<String> {
+    let mut out: Vec<String> = Vec::new();
+
+    // Duplicate node / link / group ids — each is an identity every by-id lookup
+    // and every diff index assumes is unique.
+    let mut seen_nodes: HashSet<&str> = HashSet::new();
+    for n in &model.nodes {
+        if !seen_nodes.insert(n.id.as_str()) {
+            out.push(format!("Duplicate node id: {}", n.id));
+        }
+    }
+    let mut seen_links: HashSet<&str> = HashSet::new();
+    for l in &model.links {
+        if !seen_links.insert(l.id.as_str()) {
+            out.push(format!("Duplicate link id: {}", l.id));
+        }
+    }
+    let mut seen_groups: HashSet<&str> = HashSet::new();
+    for g in &model.groups {
+        if !seen_groups.insert(g.id.as_str()) {
+            out.push(format!("Duplicate group id: {}", g.id));
+        }
+    }
+
+    // A property is keyed by (owner node, label); a repeated label on one node
+    // collapses in the diff's property index just as a responsibility id does.
+    for n in &model.nodes {
+        let mut seen: HashSet<&str> = HashSet::new();
+        for p in &n.properties {
+            if !seen.insert(p.label.as_str()) {
+                out.push(format!(
+                    "Duplicate property label '{}' on node {}",
+                    p.label, n.id
+                ));
+            }
+        }
+    }
+
+    // Responsibility ids must be globally unique across every node AND group.
+    // Both a repeat on one host and the same id living on two hosts are
+    // silent-misbind states, so report each. (This mirrors the invariant
+    // [`validate`] reports as an advisory; here it is the gating subset.)
+    let mut resp_hosts: HashMap<&str, Vec<&str>> = HashMap::new();
+    for n in &model.nodes {
+        let mut per_host: HashSet<&str> = HashSet::new();
+        for r in &n.responsibilities {
+            if !per_host.insert(r.id.as_str()) {
+                out.push(format!("Duplicate responsibility id '{}' on node {}", r.id, n.id));
+            }
+            resp_hosts.entry(r.id.as_str()).or_default().push(n.id.as_str());
+        }
+    }
+    for g in &model.groups {
+        let mut per_host: HashSet<&str> = HashSet::new();
+        for r in &g.responsibilities {
+            if !per_host.insert(r.id.as_str()) {
+                out.push(format!("Duplicate responsibility id '{}' on group {}", r.id, g.id));
+            }
+            resp_hosts.entry(r.id.as_str()).or_default().push(g.id.as_str());
+        }
+    }
+    for (rid, hosts) in &resp_hosts {
+        let mut distinct: Vec<&str> =
+            hosts.iter().copied().collect::<HashSet<&str>>().into_iter().collect();
+        if distinct.len() > 1 {
+            distinct.sort_unstable();
+            out.push(format!(
+                "Responsibility id '{}' is used on multiple hosts ({}) — responsibility ids must be globally unique",
+                rid,
+                distinct.join(", ")
+            ));
+        }
+    }
+
+    // HashMap iteration is nondeterministic; sort + de-dup for a stable message.
+    out.sort();
+    let mut seen: HashSet<String> = HashSet::new();
+    out.retain(|w| seen.insert(w.clone()));
+    out
+}
+
 /// Per-level connectivity (the C4 "same level of abstraction" rule). Each C4
 /// diagram is one level: the system context shows persons + systems; a system's
 /// container view shows its containers plus reference nodes linked into it; a
@@ -915,6 +1012,53 @@ mod resp_id_tests {
             w.contains("node-1") && w.contains("node-2") && w.contains("grp-1"),
             "names every host: {w}"
         );
+    }
+
+    /// The gating subset (`structural_violations`) catches the same-id-two-hosts
+    /// collision AND plain duplicate node ids — the silent-misbind states the
+    /// committed-write seam must refuse — while staying silent on advisories.
+    #[test]
+    fn structural_violations_flags_silent_misbind_states() {
+        use super::structural_violations;
+        let mut m = ScryModel::new();
+        m.nodes.push(node(serde_json::json!({
+            "id": "node-1", "kind": "system", "name": "Acme",
+            "responsibilities": [{ "id": "resp-1", "statement": "a" }]
+        })));
+        // A second, DISTINCT host reusing the responsibility id — the move that
+        // never cleaned up the old copy.
+        m.nodes.push(node(serde_json::json!({
+            "id": "node-2", "kind": "container", "name": "API", "parentId": "node-1",
+            "responsibilities": [{ "id": "resp-1", "statement": "b" }]
+        })));
+        // A third node reusing node-2's id — a plain duplicate node identity.
+        m.nodes.push(node(serde_json::json!({
+            "id": "node-2", "kind": "container", "name": "Dup", "parentId": "node-1",
+        })));
+        let v = structural_violations(&m);
+        assert!(v.iter().any(|w| w.contains("Duplicate node id: node-2")), "{v:?}");
+        assert!(
+            v.iter().any(|w| w.contains("globally unique") && w.contains("resp-1")),
+            "{v:?}"
+        );
+    }
+
+    /// A structurally sound model yields no gating violation — the seam only
+    /// bites genuine invariant breaks, never ordinary (or advisory-flawed)
+    /// content, so it can guard every committed write without false positives.
+    #[test]
+    fn structural_violations_empty_for_a_clean_model() {
+        use super::structural_violations;
+        let mut m = ScryModel::new();
+        m.nodes.push(node(serde_json::json!({
+            "id": "node-1", "kind": "system", "name": "Acme",
+            "responsibilities": [{ "id": "resp-1", "statement": "a" }]
+        })));
+        m.nodes.push(node(serde_json::json!({
+            "id": "node-2", "kind": "container", "name": "API", "parentId": "node-1",
+            "responsibilities": [{ "id": "resp-2", "statement": "b" }]
+        })));
+        assert!(structural_violations(&m).is_empty(), "{:?}", structural_violations(&m));
     }
 
     /// Responsibility ids that are unique across hosts raise no collision warning.

--- a/crates/scryer-mcp/src/tools/read.rs
+++ b/crates/scryer-mcp/src/tools/read.rs
@@ -1329,7 +1329,7 @@ impl ScryerServer {
     }
 
     #[tool(
-        description = "Run the structural validator over your WORKING model (the plan, with committed's code anchors overlaid) — so it sees the edits you just authored, which is what makes it a post-CLOSE gate. Returns a list of warnings: parent-kind mismatches, unknown link endpoints, group members at mixed levels, empty symbols (carrying no responsibility/property), source-map entries that reference unknown ids, and responsibility mappings whose line range covers the whole enclosing symbol (a range must be a proper subset — drop it to mean the whole definition). A clean run is a post-edit gate, not a lookup — to FIND nodes by shape on demand (e.g. every empty symbol) use `query_model`. Does NOT judge responsibility wording quality."
+        description = "Run the structural validator over your WORKING model (the plan, with committed's code anchors overlaid) — so it sees the edits you just authored, which is what makes it a post-CLOSE gate. Returns a list of warnings: parent-kind mismatches, unknown link endpoints, group members at mixed levels, empty symbols (carrying no responsibility/property), source-map entries that reference unknown ids, and responsibility mappings whose line range covers the whole enclosing symbol (a range must be a proper subset — drop it to mean the whole definition). A clean run is a post-edit gate, not a lookup — to FIND nodes by shape on demand (e.g. every empty symbol) use `query_model`. Findings come in two classes: BLOCKING invariant violations (an id the plan diff treats as unique actually names two things — a duplicate node/link/group id, or the same responsibility id on two hosts; a commit of the model is REFUSED until each clears, because the wrong copy would otherwise sit invisible to the diff forever) and advisory warnings (everything else). Does NOT judge responsibility wording quality."
     )]
     fn validate_model(
         &self,
@@ -1353,23 +1353,50 @@ impl ScryerServer {
             }
         };
         let model = scryer_core::working_view(&committed, &planned);
-        let mut warnings = validate::validate(&model);
-        warnings.extend(validate::validate_coverage(&model, model_ref.project_path()));
-        warnings.extend(scryer_extract::anchors::whole_symbol_warnings(
+
+        // Two classes, surfaced apart. BLOCKING = structural invariant violations
+        // (an id the diff treats as unique names two things); `write_model_at`
+        // refuses to persist a model carrying one, so a commit will be rejected
+        // until they clear — the agent must treat these as hard. ADVISORY = the
+        // rest (parent-kind, empty symbols, coverage, whole-symbol ranges): real
+        // gate feedback, but not commit-blocking. De-dup the advisory list against
+        // the blocking one (`validate` reports the same id-collision facts as
+        // advisories) so no single fact costs two lines.
+        let blocking = validate::structural_violations(&model);
+        let blocking_set: std::collections::HashSet<&str> =
+            blocking.iter().map(String::as_str).collect();
+        let mut advisory = validate::validate(&model);
+        advisory.retain(|w| !blocking_set.contains(w.as_str()));
+        advisory.extend(validate::validate_coverage(&model, model_ref.project_path()));
+        advisory.extend(scryer_extract::anchors::whole_symbol_warnings(
             &model,
             model_ref.project_path(),
         ));
-        if warnings.is_empty() {
-            Ok(CallToolResult::success(vec![Content::text(
+
+        if blocking.is_empty() && advisory.is_empty() {
+            return Ok(CallToolResult::success(vec![Content::text(
                 "Model is structurally clean.",
-            )]))
-        } else {
-            let mut msg = format!("Model '{}' — {} warning(s):", model_ref, warnings.len());
-            for w in &warnings {
+            )]));
+        }
+        let mut msg = format!("Model '{}':", model_ref);
+        if !blocking.is_empty() {
+            msg.push_str(&format!(
+                "\n\n{} BLOCKING invariant violation(s) — a commit of this model will be REFUSED \
+                 until each is resolved (an id the plan diff treats as unique names two things, so \
+                 the wrong copy would sit invisible):",
+                blocking.len()
+            ));
+            for w in &blocking {
                 msg.push_str(&format!("\n- {}", w));
             }
-            Ok(CallToolResult::success(vec![Content::text(msg)]))
         }
+        if !advisory.is_empty() {
+            msg.push_str(&format!("\n\n{} advisory warning(s):", advisory.len()));
+            for w in &advisory {
+                msg.push_str(&format!("\n- {}", w));
+            }
+        }
+        Ok(CallToolResult::success(vec![Content::text(msg)]))
     }
 
     #[tool(
@@ -1982,6 +2009,42 @@ mod tests {
         assert!(
             !out.contains("unknown"),
             "no unknown-reference warnings for a pending deletion: {out}"
+        );
+    }
+
+    /// The same responsibility id on two hosts — the state a botched move leaves
+    /// (added to the new host, never removed from the old) — is a BLOCKING
+    /// invariant, surfaced in its own section. The plan write path does not gate,
+    /// so the draft can hold it; `validate_model` is where the agent sees it,
+    /// before a commit is refused at the write seam.
+    #[test]
+    fn validate_model_flags_a_cross_host_duplicate_as_blocking() {
+        let dir = tempfile::tempdir().unwrap();
+        let model_ref = ModelRef::ProjectLocal(dir.path().to_path_buf());
+        let project = dir.path().to_string_lossy().to_string();
+
+        let mut committed = ScryModel::new();
+        committed.nodes.push(node("node-1", Kind::System, "Acme", None));
+        committed
+            .nodes
+            .push(node("node-2", Kind::Container, "API", Some("node-1")));
+        scryer_core::write_model_at(&model_ref, &committed).unwrap();
+
+        // The draft puts resp-1 on BOTH hosts.
+        let mut planned = committed.clone();
+        planned.nodes[0].responsibilities.push(resp("resp-1", "serve"));
+        planned.nodes[1].responsibilities.push(resp("resp-1", "serve"));
+        scryer_core::write_planned_at(&model_ref, &planned).unwrap();
+
+        let server = ScryerServer::new();
+        let r = server
+            .validate_model(Parameters(ValidateModelRequest { project: Some(project) }))
+            .unwrap();
+        let out = serde_json::to_string(&r.content).unwrap();
+        assert!(out.contains("BLOCKING"), "surfaces a blocking section: {out}");
+        assert!(
+            out.contains("globally unique") && out.contains("resp-1"),
+            "names the invariant and the colliding id: {out}"
         );
     }
 


### PR DESCRIPTION
## Problem

Responsibilities (and nodes, links, groups) are identified by a **globally-unique id**, and every consumer bakes that assumption into its data structures:

- `diff::index_responsibilities` (and the TS twin `indexResponsibilities`) build an id-keyed map with **last-write-wins** — a second copy of an id under a different host is silently dropped before the diff runs.
- `commit.rs:find_responsibility` returns the **first** match and stops.

So when a responsibility is moved from host A to host B but a stale copy is left on A (a botched move, a `set_model` overwrite, a hand-edit), the committed model holds the same id twice. The plan diff collapses each side to a single copy, `from` and `to` compare equal, **no change is emitted**, nobody is ever prompted to reconcile it, and the self-healing `retain` in the commit fold never fires. The wrong copy sits committed and **invisible indefinitely**.

`validate()` already *detects* this (the "globally unique" check), but it is advisory — nothing gates on it, so the state is reported into a warnings list no writer consults.

The underlying category: *consumers assume an invariant that only an advisory check enforces, and they encode the assumption as silent deduplication — so a violation is not merely unhandled, it is actively hidden.*

## Fix

Promote the invariant from an advisory read to a **hard gate at the one seam that persists committed state**.

1. **`scryer-core/src/validate.rs`** — new `pub fn structural_violations(model) -> Vec<String>`: the silent-misbind subset only (duplicate node/link/group ids, duplicate property labels, per-host responsibility repeats, cross-host responsibility-id collisions). It deliberately **excludes** advisory findings (length caps, disconnected nodes, link legality) that are legitimate transient states, so it can guard every write without false positives.

2. **`scryer-core/src/storage.rs`** — `write_model_at` (the single committed-layer writer every commit / fold / `set_model` rides through) now runs `structural_violations` on the exact bytes about to be written and returns `Err`, naming each violation, if any exist. A silently-misbindable duplicate can no longer reach `model.scry`.

3. **`scryer-mcp/src/tools/read.rs`** — `validate_model` now splits its output into a **BLOCKING** section (structural violations — "a commit will be REFUSED until resolved") and **advisory** warnings, de-duped against each other. The plan write path intentionally does not gate, so a draft can transiently hold a duplicate; this is where the agent sees it *before* hitting the commit refusal.

## Tests

- `structural_violations`: flags a cross-host collision + duplicate node id; empty on a clean model.
- `write_model_at`: rejects a cross-host duplicate (nothing persisted); accepts a clean model.
- `validate_model`: a draft duplicate surfaces in the BLOCKING section.

All existing tests pass; full `scryer-core` (171) and `scryer-mcp` (121) suites green on top of `main`.

## Deliberately out of scope

No new `Change` variant to surface duplicates on the live canvas diff (`diff.rs` / `planDiff.ts`) — it ripples across TS, Rust, and the UI renderer for a case the seam gate now prevents at commit, and `validate_model` already surfaces a draft duplicate. Reasonable follow-up if earlier canvas-time warning is wanted.
